### PR TITLE
[Round4] 정합성을 트랜잭션으로 보장 및 동시성 이슈 제어

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeResult.java
@@ -4,59 +4,74 @@ import com.loopers.domain.brand.Brand;
 import com.loopers.domain.like.LikeQuery;
 import com.loopers.domain.product.Product;
 import com.loopers.support.paging.Pagination;
+
 import java.util.List;
+
 import org.springframework.data.domain.Page;
 
 public class LikeResult {
 
     public record LikeRegisterResult(
-        Long userId,
-        Long productId,
-        boolean isDuplicatedRequest
+            Long userId,
+            Long productId,
+            boolean isDuplicatedRequest
     ) {
 
         public static LikeRegisterResult from(LikeQuery.LikeRegisterQuery likeRegisterQuery) {
             return new LikeRegisterResult(
-                likeRegisterQuery.likeHistory().getUserId(),
-                likeRegisterQuery.likeHistory().getProductId(),
-                likeRegisterQuery.isDuplicatedRequest()
+                    likeRegisterQuery.likeHistory().getUserId(),
+                    likeRegisterQuery.likeHistory().getProductId(),
+                    likeRegisterQuery.isDuplicatedRequest()
+            );
+        }
+
+        public static LikeRegisterResult newCreated(Long userId, Long productId) {
+            boolean isDuplicatedRequest = false;
+            return new LikeResult.LikeRegisterResult(
+                    userId, productId, isDuplicatedRequest
+            );
+        }
+        public static LikeRegisterResult duplicated(Long userId, Long productId) {
+            boolean isDuplicatedRequest = true;
+            return new LikeResult.LikeRegisterResult(
+                    userId, productId, isDuplicatedRequest
             );
         }
     }
 
     public record LikeRemoveResult(
-        Long userId,
-        Long productId,
-        boolean isDuplicatedRequest
+            Long userId,
+            Long productId,
+            boolean isDuplicatedRequest
     ) {
 
         public static LikeRemoveResult from(LikeQuery.LikeRemoveQuery likeRemoveQuery) {
             return new LikeRemoveResult(
-                likeRemoveQuery.userId(),
-                likeRemoveQuery.productId(),
-                likeRemoveQuery.isDuplicatedRequest()
+                    likeRemoveQuery.userId(),
+                    likeRemoveQuery.productId(),
+                    likeRemoveQuery.isDuplicatedRequest()
             );
         }
     }
 
     public record LikeListResult(
-        List<LikeDetailResult> contents,
-        Pagination pagination
+            List<LikeDetailResult> contents,
+            Pagination pagination
     ) {
     }
 
     public record LikeDetailResult(
-        Long productId,
-        String productName,
-        Long price,
-        String brandName
+            Long productId,
+            String productName,
+            Long price,
+            String brandName
     ) {
         public static LikeDetailResult from(Product product, Brand brand) {
             return new LikeDetailResult(
-                product.getId(),
-                product.getName(),
-                product.getPrice().getAmount(),
-                brand.getName()
+                    product.getId(),
+                    product.getName(),
+                    product.getPrice().getAmount(),
+                    brand.getName()
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeResult.java
@@ -44,12 +44,16 @@ public class LikeResult {
             Long productId,
             boolean isDuplicatedRequest
     ) {
-
-        public static LikeRemoveResult from(LikeQuery.LikeRemoveQuery likeRemoveQuery) {
+        public static LikeRemoveResult newProcess(Long userId, Long productId) {
+            boolean isDuplicatedRequest = false;
             return new LikeRemoveResult(
-                    likeRemoveQuery.userId(),
-                    likeRemoveQuery.productId(),
-                    likeRemoveQuery.isDuplicatedRequest()
+              userId, productId, isDuplicatedRequest
+            );
+        }
+        public static LikeRemoveResult duplicated(Long userId, Long productId) {
+            boolean isDuplicatedRequest = true;
+            return new LikeRemoveResult(
+                    userId, productId, isDuplicatedRequest
             );
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeUseCase.java
@@ -58,9 +58,9 @@ public class LikeUseCase {
                 .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "해당 상품에 좋아요를 해제 할 수 없습니다."));
 
         // 좋아요 해제
-        boolean isProcess = likeService.remove(userId, productId);
+        boolean isDeleted = likeService.remove(userId, productId);
 
-        if (!isProcess) {
+        if (!isDeleted) {
             return LikeResult.LikeRemoveResult.duplicated(userId, productId);
         }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeUseCase.java
@@ -16,10 +16,13 @@ import com.loopers.support.paging.PageableFactory;
 import com.loopers.support.paging.Pagination;
 import com.loopers.support.paging.PagingPolicy;
 import jakarta.transaction.Transactional;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -33,24 +36,25 @@ public class LikeUseCase {
     private final LikeProductService likeProductService = new LikeProductService();
 
     @Transactional
-    public LikeResult.LikeRegisterResult register(final Long userId, final Long productId){
-        //상품 유효성 검사
+    public LikeResult.LikeRegisterResult register(final Long userId, final Long productId) {
         Product product = productService.retrieveOne(productId)
                 .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "해당 상품에 좋아요를 할 수 없습니다."));
 
-        //좋아요 등록
-        final LikeQuery.LikeRegisterQuery likeRegisterQuery = likeService.register(userId, productId);
-
-        //좋아요 수 증가
-        if (!likeRegisterQuery.isDuplicatedRequest()) {
-            productService.increaseLikeCount(product);
+        try {
+            //좋아요 등록
+            likeService.register(userId, productId);
+        } catch (CoreException e) {
+            // 중복 요청으로 판단
+            return LikeResult.LikeRegisterResult.duplicated(userId, productId);
         }
 
-        return LikeResult.LikeRegisterResult.from(likeRegisterQuery);
+        // 좋아요 수 증가
+        productService.increaseLikeCount(product);
+        return LikeResult.LikeRegisterResult.newCreated(userId, productId);
     }
 
     @Transactional
-    public LikeResult.LikeRemoveResult remove(final Long userId, final Long productId){
+    public LikeResult.LikeRemoveResult remove(final Long userId, final Long productId) {
         //상품 유효성 검사
         Product product = productService.retrieveOne(productId)
                 .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "해당 상품에 좋아요를 해제 할 수 없습니다."));
@@ -66,15 +70,15 @@ public class LikeUseCase {
         return LikeResult.LikeRemoveResult.from(likeRemoveQuery);
     }
 
-   public LikeResult.LikeListResult retrieveLikedProducts(
-        final Long userId,
-        final Optional<PagingCondition> pagingCondition
+    public LikeResult.LikeListResult retrieveLikedProducts(
+            final Long userId,
+            final Optional<PagingCondition> pagingCondition
     ) {
         Pageable pageable = PageableFactory.from(
-            Optional.of(LikeSortType.DEFAULT),
-            pagingCondition,
-            LikeSortType.DEFAULT,
-            PagingPolicy.LIKE.getDefaultPageSize()
+                Optional.of(LikeSortType.DEFAULT),
+                pagingCondition,
+                LikeSortType.DEFAULT,
+                PagingPolicy.LIKE.getDefaultPageSize()
         );
 
         //좋아요 기록 조회
@@ -82,56 +86,36 @@ public class LikeUseCase {
 
         if (likeHistories.isEmpty()) {
             return new LikeResult.LikeListResult(
-                Collections.emptyList(),
-                new Pagination(0L, pageable.getPageNumber(), pageable.getPageSize())
+                    Collections.emptyList(),
+                    new Pagination(0L, pageable.getPageNumber(), pageable.getPageSize())
             );
         }
 
         // 상품 ID로 상품 정보 조회
         List<Long> productIds = likeHistories.getContent().stream()
-            .map(LikeHistory::getProductId)
-            .distinct()
-            .toList();
+                .map(LikeHistory::getProductId)
+                .distinct()
+                .toList();
 
         List<Product> products = productService.getProducts(productIds);
 
         List<Long> brandIds = products.stream()
-            .map(Product::getBrandId)
-            .distinct()
-            .toList();
+                .map(Product::getBrandId)
+                .distinct()
+                .toList();
 
         List<Brand> brands = brandService.getBrandsOfProducts(brandIds);
 
-       List<LikeResult.LikeDetailResult> likeDetailResults =
-           likeProductService.assembleLikeProductInfo(likeHistories.getContent(), products, brands);
+        List<LikeResult.LikeDetailResult> likeDetailResults =
+                likeProductService.assembleLikeProductInfo(likeHistories.getContent(), products, brands);
 
         return new LikeResult.LikeListResult(
-            likeDetailResults,
-            new Pagination(
-                likeHistories.getTotalElements(),
-                pageable.getPageNumber(),
-                pageable.getPageSize()
-            )
+                likeDetailResults,
+                new Pagination(
+                        likeHistories.getTotalElements(),
+                        pageable.getPageNumber(),
+                        pageable.getPageSize()
+                )
         );
     }
-
-    @Transactional
-    public LikeResult.LikeRegisterResult registerV2(final Long userId, final Long productId){
-        // 1. 상품 유효성 검사 (락 없이)
-        Product product = productService.retrieveOne(productId)
-                .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "해당 상품에 좋아요를 할 수 없습니다."));
-
-        // 2. 좋아요 등록 시도 (멱등성 검사 포함)
-        final LikeQuery.LikeRegisterQuery likeRegisterQuery = likeService.register(userId, productId);
-
-        // 3. 중복이 아닐 때만 락 걸고 좋아요 수 증가
-        if (!likeRegisterQuery.isDuplicatedRequest()) {
-            // 상품을 비관적 락으로 다시 조회
-            Product lockedProduct = productService.retrieveWithPessimisticLock(productId);
-            productService.increaseLikeCount(lockedProduct);
-        }
-
-        return LikeResult.LikeRegisterResult.from(likeRegisterQuery);
-    }
-
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/like/LikeUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/like/LikeUseCase.java
@@ -47,7 +47,7 @@ public class LikeUseCase {
         }
 
         // 좋아요 수 증가
-        productService.increaseLikeCount(product);
+        productService.increaseLikeCountAtomically(product);
         return LikeResult.LikeRegisterResult.newCreated(userId, productId);
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderResult.java
@@ -25,14 +25,5 @@ public class OrderResult {
                 createdOrder.getStatus()
             );
         }
-
-        public static OrderRequestResult failValidation(Order order) {
-            return new OrderRequestResult(
-                    false,
-                    order.getId(),
-                    order.getStatus()
-            );
-        }
     }
-
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderUseCase.java
@@ -3,6 +3,7 @@ package com.loopers.application.order;
 import com.loopers.domain.commonvo.Money;
 import com.loopers.domain.coupon.Coupon;
 import com.loopers.domain.coupon.CouponService;
+import com.loopers.domain.coupon.UserCoupon;
 import com.loopers.domain.order.*;
 import com.loopers.domain.point.PointService;
 import com.loopers.domain.product.Product;
@@ -58,12 +59,15 @@ public class OrderUseCase {
         Money orderAmount = orderService.calculateOrderAmountByAddLines(order, orderLines);
 
         // 4-0 쿠폰 정보 확인 및 할인 금액 계산
-        final List<Coupon> allValidCoupons;
+        final List<UserCoupon> userCoupons;
         try {
-        couponService.findAllValidCouponsOrThrow(userCouponIds);
+            userCoupons = couponService.findAllValidCouponsOrThrow(userCouponIds);
+        } catch (CoreException e) {
+            throw new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 쿠폰입니다.");
+        }
+        Money discountAmount = couponService.use(userCoupons, orderAmount);
 
         // 4. 할인 정보 확인
-        Money discountAmount = Money.ZERO;
         Money paymentAmount = orderService.calculatePaymentAmount(order, discountAmount);
 
         // 5. 주문 총액만큼 포인트 보유 확인

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderUseCase.java
@@ -42,7 +42,8 @@ public class OrderUseCase {
             allValidProducts = productService.findAllValidProductsOrThrow(
                     items.stream()
                             .map(OrderInfo.ItemInfo::productId)
-                            .collect(Collectors.toSet())
+                            .distinct()
+                            .toList()
             );
         } catch (CoreException e) {
             orderService.failValidation(order);

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderUseCase.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -67,9 +68,9 @@ public class OrderUseCase {
                     .map(couponService::findAllValidCouponsOrThrow)
                     .map(coupons -> couponService.use(coupons, orderAmount))
                     .orElse(Money.ZERO);
-        } catch (CoreException e) {
+        } catch (CoreException | ObjectOptimisticLockingFailureException e) {
             orderService.failValidation(order);
-            throw e;
+            throw new CoreException(ErrorType.CONFLICT, "쿠폰 정보가 유효하지 않습니다.");
         }
 
         // 4. 할인 정보 확인

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFailureHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFailureHandler.java
@@ -1,0 +1,33 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.order.Order;
+import com.loopers.domain.order.OrderService;
+import com.loopers.domain.payment.PaymentFailureReason;
+import com.loopers.domain.payment.PaymentService;
+import com.loopers.support.error.CoreException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentFailureHandler {
+
+    private final OrderService orderService;
+    private final PaymentService paymentService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(Long userId, PaymentInfo.Pay payInfo, PaymentFailureReason paymentFailureReason) {
+        Order order = orderService.getUserOrder(userId, payInfo.orderId());
+        boolean isOrderConfirmed = false;
+        orderService.finalizeOrderResult(order, isOrderConfirmed);
+
+        paymentService.saveFailure(
+                payInfo.orderId(),
+                payInfo.paymentMethod(),
+                order.getPaymentAmount(),
+                paymentFailureReason
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentResult.java
@@ -7,9 +7,8 @@ public class PaymentResult {
             Long paymentId,
             PaymentStatus paymentStatus
     ) {
-        public static Pay of(Long paymentId, boolean isPaymentConfirmed) {
-            PaymentStatus paymentStatus = isPaymentConfirmed ? PaymentStatus.CONFIRMED : PaymentStatus.CANCELED;
-            return new Pay(paymentId, paymentStatus);
+        public static Pay of(Long paymentId) {
+            return new Pay(paymentId, PaymentStatus.CONFIRMED);
         }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentUseCase.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentUseCase.java
@@ -48,7 +48,7 @@ public class PaymentUseCase {
 
         // OrderLine에서 상품 및 수량 확인
         List<Long> productIds = orderLines.stream()
-                .map(OrderLine::getId)
+                .map(OrderLine::getProductId)
                 .toList();
 
         // 1. 재고 차감
@@ -69,7 +69,7 @@ public class PaymentUseCase {
         }
 
         // 2. 포인트 결제
-        Point point = pointService.findByUser(userId);
+        Point point = pointService.findByUserWithLock(userId);
         pointService.useOrThrow(point, order.getPaymentAmount());
 
         // 3. 결제 성공 처리

--- a/apps/commerce-api/src/main/java/com/loopers/domain/commonvo/Quantity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/commonvo/Quantity.java
@@ -5,19 +5,18 @@ import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Embeddable;
 import java.util.Objects;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Quantity {
 
+    public static final Quantity ZERO = new Quantity(0);
     private int amount;
-
-    private Quantity(int amount) {
-        this.amount = amount;
-    }
 
     public static Quantity of(int amount) {
         if (amount < 1) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/commonvo/Quantity.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/commonvo/Quantity.java
@@ -33,15 +33,15 @@ public class Quantity {
 
     public Quantity subtract(Quantity other) {
         int result = this.amount - other.amount;
-        if (!isPositive(result)) {
+        if (isNegative(result)) {
             throw new CoreException(ErrorType.BAD_REQUEST, "수량은 0 이상이어야 합니다.");
         }
 
         return new Quantity(result);
     }
 
-    public boolean isPositive(int value) {
-        return value > 0;
+    public boolean isNegative(int value) {
+        return value < 0;
     }
 
     public boolean isGreaterThan(Quantity other) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
@@ -31,6 +31,24 @@ public class Coupon {
     @Column(nullable = false)
     private LocalDate endAt;
 
+    public static Coupon create(String name, DiscountPolicy discountPolicy, LocalDate startAt, LocalDate endAt) {
+        if ("".equals(name)) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "쿠폰 이름은 필수입니다.");
+        }
+        if (discountPolicy == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "할인 정책은 필수입니다.");
+        }
+        if (startAt == null || endAt == null || !startAt.isBefore(endAt)) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "유효한 시작일과 종료일을 입력해야 합니다.");
+        }
+        return Coupon.builder()
+                .name(name)
+                .discountPolicy(discountPolicy)
+                .startAt(startAt)
+                .endAt(endAt)
+                .build();
+    }
+
     private boolean isUsable() {
         LocalDate today = LocalDate.now();
         return !today.isBefore(startAt)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/Coupon.java
@@ -1,0 +1,45 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "coupon")
+public class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Embedded
+    private DiscountPolicy discountPolicy;
+
+    @Column(nullable = false)
+    private LocalDate startAt;
+
+    @Column(nullable = false)
+    private LocalDate endAt;
+
+    private boolean isUsable() {
+        LocalDate today = LocalDate.now();
+        return !today.isBefore(startAt)
+                && !today.isAfter(endAt);
+    }
+
+    public void validateUsable() {
+        if (!isUsable()) {
+            throw new CoreException(ErrorType.CONFLICT, "사용할 수 없는 쿠폰입니다.");
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.coupon;
+
+import java.util.List;
+
+public interface CouponRepository {
+    List<Coupon> findAllById(List<Long> userCouponIds);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -4,4 +4,5 @@ import java.util.List;
 
 public interface CouponRepository {
     List<Coupon> findAllById(List<Long> userCouponIds);
+    Coupon save(Coupon coupon);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -37,17 +37,14 @@ public class CouponService {
         return userCoupons;
     }
 
-    @Transactional
+    //todo: @Transactional 달았을 때 UnexpectedRollbackException 발생
     public Money use(List<UserCoupon> userCoupons, Money orderAmount) {
-        log.info("*******Using coupons: {}", userCoupons);
         if (userCoupons == null || userCoupons.isEmpty()) {
             return Money.ZERO;
         }
 
         // 유효성 검사
         userCoupons.forEach(UserCoupon::validateUsable);
-        log.info("********All coupons are valid.");
-
 
         // 할인 금액 계산 후 합산
         Money totalDiscount = userCoupons.stream()

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,6 +1,6 @@
 package com.loopers.domain.coupon;
 
-import com.loopers.domain.product.Product;
+import com.loopers.domain.commonvo.Money;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -14,23 +14,46 @@ import java.util.stream.Collectors;
 @Component
 public class CouponService {
 
-    private final CouponRepository couponRepository;
+    private final UserCouponRepository userCouponRepository;
 
-    public List<Coupon> findAllValidCouponsOrThrow(List<Long> userCouponIds) {
+    public List<UserCoupon> findAllValidCouponsOrThrow(List<Long> userCouponIds) {
         if (userCouponIds == null || userCouponIds.isEmpty()) {
             throw new CoreException(ErrorType.BAD_REQUEST, "User coupon IDs must not be null or empty.");
         }
 
-        List<Coupon> coupons = couponRepository.findAllById(userCouponIds);
+        List<UserCoupon> userCoupons = userCouponRepository.findAllById(userCouponIds);
 
-        Set<Long> foundIds = coupons.stream()
-                .map(Coupon::getId)
+        Set<Long> foundIds = userCoupons.stream()
+                .map(UserCoupon::getId)
                 .collect(Collectors.toSet());
 
         if (!foundIds.containsAll(userCouponIds)) {
             throw new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 쿠폰입니다.");
         }
 
-        return coupons;
+        return userCoupons;
     }
+
+    public Money use(List<UserCoupon> userCoupons,Money orderAmount) {
+        if (userCoupons == null || userCoupons.isEmpty()) {
+            return Money.ZERO;
+        }
+
+        // 유효성 검사
+        userCoupons.forEach(UserCoupon::validateUsable);
+
+        // 할인 금액 계산 후 합산
+        Money totalDiscount = userCoupons.stream()
+                .map(userCoupon -> {
+                    Coupon coupon = userCoupon.getCoupon();
+                    return coupon.getDiscountPolicy()
+                            .getDiscountType()
+                            .calculateDiscountAmount(orderAmount.getAmount(), coupon.getDiscountPolicy().getDiscountValue());
+                })
+                .reduce(Money.ZERO, Money::add);
+
+        return totalDiscount;
+    }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,0 +1,36 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.product.Product;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Component
+public class CouponService {
+
+    private final CouponRepository couponRepository;
+
+    public List<Coupon> findAllValidCouponsOrThrow(List<Long> userCouponIds) {
+        if (userCouponIds == null || userCouponIds.isEmpty()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "User coupon IDs must not be null or empty.");
+        }
+
+        List<Coupon> coupons = couponRepository.findAllById(userCouponIds);
+
+        Set<Long> foundIds = coupons.stream()
+                .map(Coupon::getId)
+                .collect(Collectors.toSet());
+
+        if (!foundIds.containsAll(userCouponIds)) {
+            throw new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 쿠폰입니다.");
+        }
+
+        return coupons;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponUseHistory.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponUseHistory.java
@@ -1,0 +1,61 @@
+package com.loopers.domain.coupon;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "coupon_use_history")
+public class CouponUseHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_coupon_id", nullable = false)
+    private Long userCouponId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
+    @Column(name = "used_at", nullable = true)
+    private LocalDateTime usedAt;
+
+    @Column(name = "restored_at", nullable = true)
+    private LocalDateTime restoredAt;
+
+    @Column(name = "amount", nullable = false)
+    private BigDecimal amount;
+
+    public static CouponUseHistory record(Long userCouponId, Long userId, Long orderId, BigDecimal amount) {
+        return CouponUseHistory.builder()
+                .userCouponId(userCouponId)
+                .userId(userId)
+                .orderId(orderId)
+                .usedAt(LocalDateTime.now())
+                .amount(amount)
+                .build();
+    }
+
+    public static CouponUseHistory restore(Long userCouponId, Long userId, Long orderId, BigDecimal amount) {
+        return CouponUseHistory.builder()
+                .userCouponId(userCouponId)
+                .userId(userId)
+                .orderId(orderId)
+                .restoredAt(LocalDateTime.now())
+                .amount(amount)
+                .build();
+    }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountPolicy.java
@@ -18,7 +18,7 @@ public class DiscountPolicy {
     @Column(name = "discount_type", nullable = false)
     private DiscountType discountType;
 
-    @Column(precision = 8, scale = 3, name = "discount_rate", nullable = false)
+    @Column(precision = 8, scale = 3, name = "discount_value", nullable = false)
     private BigDecimal discountValue; // 예: 10% => 0.100, 10,000 => 10000.000
 
     public static DiscountPolicy of(

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountPolicy.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountPolicy.java
@@ -1,0 +1,33 @@
+package com.loopers.domain.coupon;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class DiscountPolicy {
+
+    @Convert(converter = DiscountTypeConverter.class)
+    @Column(name = "discount_type", nullable = false)
+    private DiscountType discountType;
+
+    @Column(precision = 8, scale = 3, name = "discount_rate", nullable = false)
+    private BigDecimal discountValue; // 예: 10% => 0.100, 10,000 => 10000.000
+
+    public static DiscountPolicy of(
+            DiscountType discountType,
+            BigDecimal discountValue
+    ) {
+        return DiscountPolicy.builder()
+                .discountType(discountType)
+                .discountValue(discountValue)
+                .build();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountType.java
@@ -1,0 +1,37 @@
+package com.loopers.domain.coupon;
+
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import com.loopers.domain.commonvo.Money;
+
+public enum DiscountType {
+
+    RATE {
+        @Override
+        public Money calculateDiscountAmount(Long totalPrice, BigDecimal discountValue) {
+            if (totalPrice == null || discountValue == null) return Money.ZERO;
+
+            BigDecimal price = BigDecimal.valueOf(totalPrice);
+            long discounted = price.multiply(discountValue)
+                    .setScale(0, RoundingMode.DOWN)
+                    .longValue();
+
+            return Money.of(discounted);
+        }
+    },
+
+    FIXED_AMOUNT {
+        @Override
+        public Money calculateDiscountAmount(Long totalPrice, BigDecimal discountValue) {
+            if (discountValue == null) return Money.ZERO;
+
+            long discounted = discountValue.setScale(0, RoundingMode.DOWN).longValue();
+            return Money.of(discounted);
+        }
+    };
+
+    public abstract Money calculateDiscountAmount(Long totalPrice, BigDecimal discountValue);
+}
+
+

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountTypeConverter.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/DiscountTypeConverter.java
@@ -1,0 +1,18 @@
+package com.loopers.domain.coupon;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class DiscountTypeConverter implements AttributeConverter<DiscountType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(DiscountType attribute) {
+        return attribute != null ? attribute.name() : null;
+    }
+
+    @Override
+    public DiscountType convertToEntityAttribute(String dbData) {
+        return dbData != null ? DiscountType.valueOf(dbData) : null;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
@@ -29,6 +29,9 @@ public class UserCoupon {
     @Column(name = "used", nullable = false)
     private boolean used;
 
+    @Version
+    private Long version;
+
     @Column(name = "issued_at", nullable = false)
     private LocalDate issuedAt;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
@@ -3,12 +3,15 @@ package com.loopers.domain.coupon;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "user_coupon")
 public class UserCoupon {
@@ -32,6 +35,18 @@ public class UserCoupon {
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
 
+    public static UserCoupon create(Long userId, Coupon coupon) {
+        if (userId == null || coupon == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "사용자 아이디와 쿠폰은 필수입니다.");
+        }
+        return UserCoupon.builder()
+                .userId(userId)
+                .coupon(coupon)
+                .used(false)
+                .issuedAt(LocalDate.now())
+                .build();
+    }
+
     public void markUsed() {
         this.used = true;
     }
@@ -46,4 +61,6 @@ public class UserCoupon {
         }
         coupon.validateUsable();
     }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
@@ -1,0 +1,45 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "user_coupon")
+public class UserCoupon {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "coupon_id", nullable = false)
+    private Coupon coupon;
+
+    @Column(name = "used", nullable = false)
+    private boolean used;
+
+    @Column(name = "issued_at", nullable = false)
+    private LocalDate issuedAt;
+
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    public void markUsed() {
+        this.used = true;
+    }
+
+    public void markRestore() {
+        this.used = false;
+    }
+
+    public void validateUsable() {
+        if (this.used) {
+            throw new CoreException(ErrorType.CONFLICT, "이미 사용된 쿠폰입니다.");
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
@@ -12,6 +12,9 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "user_coupon")
 public class UserCoupon {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
@@ -41,5 +44,6 @@ public class UserCoupon {
         if (this.used) {
             throw new CoreException(ErrorType.CONFLICT, "이미 사용된 쿠폰입니다.");
         }
+        coupon.validateUsable();
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
@@ -1,9 +1,12 @@
 package com.loopers.domain.coupon;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserCouponRepository {
     List<UserCoupon> findAllById(List<Long> userCouponIds);
 
     UserCoupon save(UserCoupon userCoupon);
+
+    Optional<UserCoupon> findById(Long couponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.coupon;
+
+import java.util.List;
+
+public interface UserCouponRepository {
+    List<UserCoupon> findAllById(List<Long> userCouponIds);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
@@ -4,4 +4,6 @@ import java.util.List;
 
 public interface UserCouponRepository {
     List<UserCoupon> findAllById(List<Long> userCouponIds);
+
+    UserCoupon save(UserCoupon userCoupon);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeHistoryRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeHistoryRepository.java
@@ -13,4 +13,8 @@ public interface LikeHistoryRepository {
     Optional<LikeHistory> findByUserIdAndProductId(Long userId, Long productId);
 
     Page<LikeHistory> findByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
+
+    int deleteByUserIdAndProductId(Long userId, Long productId);
+
+    void deleteAll();
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -27,22 +27,9 @@ public class LikeService {
         return likeHistory;
     }
 
-    public LikeQuery.LikeRemoveQuery remove(final Long userId, final Long productId) {
-        final LikeHistory existing = likeHistoryRepository.findByUserIdAndProductId(userId, productId)
-                .orElse(null);
-
-        if (existing == null) {
-            return LikeQuery.LikeRemoveQuery.alreadyRemoved(userId, productId);
-        }
-
-        if(existing.isDeleted()){
-            return LikeQuery.LikeRemoveQuery.alreadyRemoved(userId,productId);
-        }
-
-        existing.delete();
-        likeHistoryRepository.save(existing);
-
-        return LikeQuery.LikeRemoveQuery.success(userId, productId);
+    public boolean remove(final Long userId, final Long productId) {
+        int deletedCount = likeHistoryRepository.deleteByUserIdAndProductId(userId, productId);
+        return deletedCount > 0;
     }
 
     public Page<LikeHistory> retrieveHistories(final Long userId, final Pageable pageable) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -52,6 +52,7 @@ public class Order {
     @AttributeOverride(name = "amount", column = @Column(name = "payment_amount"))
     private Money paymentAmount;
 
+    @Column(name = "order_request_id", unique = true, nullable = false)
     private String orderRequestId; // 멱등키
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderLine.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderLine.java
@@ -24,6 +24,7 @@ public class OrderLine {
     @JoinColumn(name = "order_id")
     private Order order;
 
+    @Column(name = "product_id", nullable = false)
     private Long productId;
 
     @Embedded
@@ -35,7 +36,7 @@ public class OrderLine {
 
     @Embedded
     @AttributeOverrides({
-            @AttributeOverride(name = "amount", column = @Column(name = "discount_amount"))
+            @AttributeOverride(name = "amount", column = @Column(name = "product_price"))
     })
     private Money price;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderLineService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderLineService.java
@@ -4,16 +4,17 @@ import com.loopers.domain.product.Product;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class OrderLineService {
 
-    public List<OrderLine> createOrderLines(final List<OrderLineCommand> lines, final List<Product> products) {
+    public List<OrderLine> createOrderLinesOld(final List<OrderLineCommand> lines, final List<Product> products) {
+        if(lines.size()!= products.size()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "주문 라인과 상품의 개수가 일치하지 않습니다.");
+        }
+
         final Map<Long, Product> productMap = products.stream()
                 .collect(Collectors.toMap(Product::getId, Function.identity()));
 
@@ -23,6 +24,37 @@ public class OrderLineService {
                     .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품 없음: " + line.productId()));
             orderLines.add(OrderLine.create(line.productId(), line.quantity(), product.getPrice()));
         }
+        return orderLines;
+    }
+
+    public List<OrderLine> createOrderLines(final List<OrderLineCommand> lines, final List<Product> products) {
+        //수량 일치 검증
+        if (products.size() != lines.size()) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "상품 수와 주문 라인이 일치하지 않습니다.");
+        }
+
+        //  productId → Product 매핑
+        final Map<Long, Product> productMap = products.stream()
+                .collect(Collectors.toMap(Product::getId, Function.identity()));
+
+        // 요청 productID 목록
+        final Set<Long> requestedIds = lines.stream()
+                .map(OrderLineCommand::productId)
+                .collect(Collectors.toSet());
+
+        // ID 누락 검증
+        final Set<Long> actualIds = productMap.keySet();
+        if (!actualIds.containsAll(requestedIds)) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "상품 수와 주문 라인이 일치하지 않습니다.");
+        }
+
+        // 매핑 및 생성
+        List<OrderLine> orderLines = new ArrayList<>();
+        for (OrderLineCommand line : lines) {
+            Product product = productMap.get(line.productId()); // null 아님이 보장됨
+            orderLines.add(OrderLine.create(line.productId(), line.quantity(), product.getPrice()));
+        }
+
         return orderLines;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderRepository.java
@@ -9,4 +9,6 @@ public interface OrderRepository {
     Order save(Order order);
 
     Optional<Order> findByIdWithOrderLines(Long id);
+
+    Long findTotalPaymentAmountByUserId(Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -42,7 +42,7 @@ public class OrderService {
                 .orElseThrow(() -> new CoreException(ErrorType.FORBIDDEN, "해당 사용자의 주문이 아닙니다."));
     }
 
-    public void finalizePaymentResult(Order order, boolean isPaymentConfirmed) {
+    public void finalizeOrderResult(Order order, boolean isPaymentConfirmed) {
         if (isPaymentConfirmed) {
             order.markPaid();
         } else {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
@@ -36,6 +36,9 @@ public class Payment {
     @Column(name = "payment_status", nullable = false)
     private PaymentStatus paymentStatus;
 
+    @Column(name = "failure_reason", nullable = true)
+    private PaymentFailureReason failureReason;
+
     private ZonedDateTime createdAt;
     private ZonedDateTime updatedAt;
     private ZonedDateTime deletedAt;
@@ -49,7 +52,18 @@ public class Payment {
         this.createdAt = ZonedDateTime.now();
     }
 
-    public static Payment confirm(Long orderId, PaymentMethod paymentMethod, Money amount, PaymentStatus paymentStatus) {
+    private Payment(Long orderId, PaymentMethod paymentMethod, Money amount, PaymentStatus paymentStatus, PaymentFailureReason failureReason) {
+        this.orderId = orderId;
+        this.paymentMethod = paymentMethod;
+        this.amount = amount;
+        this.paymentStatus = paymentStatus;
+        this.failureReason = failureReason;
+        this.createdAt = ZonedDateTime.now();
+    }
+
+    public static Payment confirmSuccess(
+            Long orderId, PaymentMethod paymentMethod, Money amount, PaymentStatus paymentStatus
+    ) {
         if (orderId == null || paymentMethod == null || amount == null || paymentStatus == null) {
             throw new CoreException(ErrorType.BAD_REQUEST, "주문 ID, 결제 방법, 결제 금액, 결제 상태는 필수입니다.");
         }
@@ -58,5 +72,19 @@ public class Payment {
         }
 
         return new Payment(orderId, paymentMethod, amount, paymentStatus);
+    }
+
+    public static Payment confirmFailure(
+            Long orderId, PaymentMethod paymentMethod, Money amount, PaymentStatus paymentStatus,
+            PaymentFailureReason paymentFailureReason
+    ) {
+        if (orderId == null || paymentMethod == null || amount == null || paymentStatus == null) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "주문 ID, 결제 방법, 결제 금액, 결제 상태는 필수입니다.");
+        }
+        if (amount.getAmount() < 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "결제 금액은 0이상이여야 합니다.");
+        }
+
+        return new Payment(orderId, paymentMethod, amount, paymentStatus, paymentFailureReason);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentFailureReason.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentFailureReason.java
@@ -3,13 +3,22 @@ package com.loopers.domain.payment;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
 @Getter
 @RequiredArgsConstructor
 public enum PaymentFailureReason {
     OUT_OF_STOCK("재고 부족"),
     INSUFFICIENT_BALANCE("잔액 부족"),
     INVALID_PAYMENT_DETAILS("잘못된 결제 정보"),
-    ORDER_NOT_FOUND("주문을 찾을 수 없음");
+    ORDER_NOT_FOUND("주문을 찾을 수 없음"),
+    UNKNOWN("알 수 없는 오류");
 
     private final String message;
+
+    public static PaymentFailureReason fromMessage(String msg) {
+        return Arrays.stream(values())
+                .filter(r -> msg.contains(r.getMessage()))
+                .findFirst()
+                .orElse(UNKNOWN);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentFailureReason.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentFailureReason.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.payment;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentFailureReason {
+    OUT_OF_STOCK("재고 부족"),
+    INSUFFICIENT_BALANCE("잔액 부족"),
+    INVALID_PAYMENT_DETAILS("잘못된 결제 정보"),
+    ORDER_NOT_FOUND("주문을 찾을 수 없음");
+
+    private final String message;
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentRepository.java
@@ -1,7 +1,12 @@
 package com.loopers.domain.payment;
 
+
 import java.util.Optional;
 
 public interface PaymentRepository {
     Payment save(Payment payment);
+
+    Optional<Payment> findById(Long paymentId);
+
+    Optional<Payment> findByOrderId(Long orderId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/PaymentService.java
@@ -10,11 +10,27 @@ public class PaymentService {
 
     private final PaymentRepository paymentRepository;
 
-    public Long save(
-            Long orderId, PaymentMethod paymentMethod, Money amount, boolean isPaymentConfirmed
+    public Long saveSuccess(
+            final Long orderId, final PaymentMethod paymentMethod, final Money amount
     ) {
-        PaymentStatus paymentStatus = isPaymentConfirmed ? PaymentStatus.CONFIRMED : PaymentStatus.CANCELED;
-        final Payment payment = paymentRepository.save(Payment.confirm(orderId, paymentMethod, amount, paymentStatus));
+        final Payment payment = paymentRepository.save(
+                Payment.confirmSuccess(orderId, paymentMethod, amount, PaymentStatus.CONFIRMED)
+        );
+
+        return payment.getId();
+    }
+
+    public Long saveFailure(
+            final Long orderId,
+            final PaymentMethod paymentMethod,
+            final Money amount,
+            final PaymentFailureReason failureReason
+    ) {
+        final Payment payment = paymentRepository.save(
+                Payment.confirmFailure(
+                        orderId, paymentMethod, amount, PaymentStatus.CANCELED, failureReason
+                )
+        );
 
         return payment.getId();
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
@@ -18,7 +18,8 @@ public class Point {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "balance", nullable = false))
     private Money amount;
 
     @Column(nullable = false, unique = true)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/Point.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.point;
 
 import com.loopers.domain.commonvo.Money;
+import com.loopers.domain.payment.PaymentFailureReason;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;
@@ -62,7 +63,7 @@ public class Point {
             throw new CoreException(ErrorType.BAD_REQUEST, "사용할 포인트는 0 이상이어야 합니다.");
         }
         if (this.amount.isLessThan(paymentAmount)) {
-            throw new CoreException(ErrorType.CONFLICT, "사용할 포인트가 잔액보다 많습니다.");
+            throw new CoreException(ErrorType.CONFLICT, PaymentFailureReason.INSUFFICIENT_BALANCE.getMessage());
         }
         this.amount = this.amount.subtract(paymentAmount);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -9,4 +9,5 @@ public interface PointRepository {
     Optional<Point> findByUserId(Long userId);
     Point save(Point point);
 
+    Optional<Point> findByUserIdWithLock(Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -52,7 +52,7 @@ public class PointService {
                     .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
             point.use(paymentAmount);
-        }catch (Exception e) {
+        }catch (CoreException e) {
             return false;
         }
         return true;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -53,4 +53,9 @@ public class PointService {
         return pointRepository.findByUserId(userId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다."));
     }
+
+    public Point findByUserWithLock(Long userId) {
+        return pointRepository.findByUserIdWithLock(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -1,6 +1,7 @@
 package com.loopers.domain.point;
 
 import com.loopers.domain.commonvo.Money;
+import com.loopers.domain.order.Order;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +37,7 @@ public class PointService {
         return pointRepository.findByUserId(userId);
     }
 
-    public void checkSufficientBalance(final Long userId, final Money paymentAmount) {
+    public void validateSufficientBalance(final Long userId, final Money paymentAmount) {
         final Point point = pointRepository.findByUserId(userId)
                 .orElseThrow(() -> new CoreException(ErrorType.CONFLICT, "잔액이 부족합니다."));
 
@@ -45,7 +46,6 @@ public class PointService {
         }
     }
 
-    //todo: 테코 작성
     public boolean use(Long userId, Money paymentAmount) {
         try {
             Point point = pointRepository.findByUserId(userId)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.point;
 
 import com.loopers.domain.commonvo.Money;
-import com.loopers.domain.order.Order;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -46,15 +45,12 @@ public class PointService {
         }
     }
 
-    public boolean use(Long userId, Money paymentAmount) {
-        try {
-            Point point = pointRepository.findByUserId(userId)
-                    .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+    public void useOrThrow(Point point, Money paymentAmount) {
+        point.use(paymentAmount);
+    }
 
-            point.use(paymentAmount);
-        }catch (CoreException e) {
-            return false;
-        }
-        return true;
+    public Point findByUser(Long userId) {
+        return pointRepository.findByUserId(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "사용자를 찾을 수 없습니다."));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -3,15 +3,7 @@ package com.loopers.domain.product;
 import com.loopers.domain.commonvo.*;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
 import java.time.LocalDate;
 
@@ -46,8 +38,11 @@ public class Product {
     @Convert(converter = LikeCountConverter.class)
     private LikeCount likeCount;
 
+    @Embedded
+    @AttributeOverride(name = "amount", column = @Column(name = "stock_quantity", nullable = false))
     private Quantity stockQuantity; //TODO: Inventory에서 관리여부를 고민
 
+    @Column(name = "sale_start_date", nullable = false)
     private LocalDate saleStartDate;
 
     @Column(nullable = false, name = "brand_id")

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/Product.java
@@ -12,9 +12,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+
 import java.time.LocalDate;
 
 import java.time.ZonedDateTime;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -56,44 +58,44 @@ public class Product {
     private ZonedDateTime deletedAt;
 
     public static Product from(
-        String name,
-        Long price,
-        ProductStatus status,
-        int likeCount,
-        Quantity stockQuantity,
-        LocalDate saleStartDate,
-        Long brandId
+            String name,
+            Long price,
+            ProductStatus status,
+            int likeCount,
+            Quantity stockQuantity,
+            LocalDate saleStartDate,
+            Long brandId
     ) {
         return Product.builder()
-            .name(name)
-            .price(Money.of(price))
-            .status(status)
-            .likeCount(LikeCount.from(likeCount))
-            .stockQuantity(stockQuantity)
-            .saleStartDate(saleStartDate)
-            .brandId(brandId)
-            .build();
+                .name(name)
+                .price(Money.of(price))
+                .status(status)
+                .likeCount(LikeCount.from(likeCount))
+                .stockQuantity(stockQuantity)
+                .saleStartDate(saleStartDate)
+                .brandId(brandId)
+                .build();
     }
 
     public static Product testInstance(
-        String name,
-        Long price,
-        ProductStatus status,
-        int likeCount,
-        Quantity stockQuantity,
-        LocalDate saleStartDate,
-        Long brandId
+            String name,
+            Long price,
+            ProductStatus status,
+            int likeCount,
+            Quantity stockQuantity,
+            LocalDate saleStartDate,
+            Long brandId
     ) {
         return Product.builder()
-            .id(0L)
-            .name(name)
-            .price(Money.of(price))
-            .status(status)
-            .likeCount(LikeCount.from(likeCount))
-            .stockQuantity(stockQuantity)
-            .saleStartDate(saleStartDate)
-            .brandId(brandId)
-            .build();
+                .id(0L)
+                .name(name)
+                .price(Money.of(price))
+                .status(status)
+                .likeCount(LikeCount.from(likeCount))
+                .stockQuantity(stockQuantity)
+                .saleStartDate(saleStartDate)
+                .brandId(brandId)
+                .build();
     }
 
     public void increaseLikeCount() {
@@ -108,7 +110,12 @@ public class Product {
         if (quantity.isGreaterThan(this.stockQuantity)) {
             throw new CoreException(ErrorType.BAD_REQUEST, "재고가 부족합니다.");
         }
-        this.stockQuantity = this.stockQuantity.subtract(quantity);
+
+        Quantity remainingStock = this.stockQuantity.subtract(quantity);
+        if (remainingStock.equals(Quantity.ZERO)) {
+            markSoldOut();
+        }
+        this.stockQuantity = remainingStock;
     }
 
     public void markSoldOut() {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductCommand.java
@@ -12,4 +12,13 @@ public class ProductCommand {
             return new CheckStock(productId, quantity);
         }
     }
+
+    public record DeductStock(
+            Product product,
+            Quantity quantity
+    ) {
+        public static DeductStock of(Product product, Quantity quantity) {
+            return new DeductStock(product, quantity);
+        }
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -22,4 +22,6 @@ public interface ProductRepository {
     int updateLikeCountById(Long id);
 
     int decreaseLikeCountById(Long id);
+
+    List<Product> findAllValidWithPessimisticLock(List<Long> productIds);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -20,4 +20,6 @@ public interface ProductRepository {
     List<Product> findAllByIds(List<Long> productIds);
 
     int updateLikeCountById(Long id);
+
+    int decreaseLikeCountById(Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -18,4 +18,6 @@ public interface ProductRepository {
     List<Product> findAll();
 
     List<Product> findAllByIds(List<Long> productIds);
+
+    int updateLikeCountById(Long id);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -44,8 +44,8 @@ public class ProductService {
         return productRepository.findAllByIds(productIds);
     }
 
-    public List<Product> findAllValidProductsOrThrow(Set<Long> productIds) {
-        List<Product> products = productRepository.findAllByIds(productIds.stream().toList());
+    public List<Product> findAllValidProductsOrThrow(List<Long> productIds) {
+        List<Product> products = productRepository.findAllByIds(productIds);
 
         Set<Long> foundIds = products.stream()
                 .map(Product::getId)
@@ -58,54 +58,20 @@ public class ProductService {
         return products;
     }
 
-    /*public boolean deductStock(List<ProductCommand.CheckStock> commands) {
-        Set<Long> productIds = commands.stream().map(ProductCommand.CheckStock::productId).collect(Collectors.toSet());
-        List<Product> products = productRepository.findAllByIds(productIds.stream().toList());
-
-        for (ProductCommand.CheckStock command : commands) {
-            Product product = products.stream()
-                    .filter(p -> p.getId().equals(command.productId()))
-                    .findFirst()
-                    .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품 없음: " + command.productId()));
-
-            try {
-                product.deductStock(command.quantity());
-            } catch (CoreException e) {
-                // TODO: 재고 부족 시 상품 상태 일시품절 처리 (비동기)
-                product.markSoldOut();
-                return false;
-            }
-        }
-        return true;
-    }*/
-    public boolean deductStock(List<ProductCommand.CheckStock> commands) {
-        Set<Long> productIds = commands.stream()
-                .map(ProductCommand.CheckStock::productId)
-                .collect(Collectors.toSet());
-
-        List<Product> products = productRepository.findAllByIds(productIds.stream().toList());
-
+    public boolean deductStock(final List<ProductCommand.DeductStock> commands) {
         // 1. 재고 검증 (재고 수량 변경 없이)
-        for (ProductCommand.CheckStock command : commands) {
-            Product product = products.stream()
-                    .filter(p -> p.getId().equals(command.productId()))
-                    .findFirst()
-                    .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품 없음: " + command.productId()));
-
+        for (ProductCommand.DeductStock command : commands) {
+            Product product = command.product();
             if (command.quantity().isGreaterThan(product.getStockQuantity())) {
-                product.markSoldOut(); // 일시품절 처리 todo: 비동기 처리 필요
+                product.markSoldOut();
                 return false;
             }
         }
 
         // 2. 재고 차감 (모든 검증 통과 후)
-        for (ProductCommand.CheckStock command : commands) {
-            Product product = products.stream()
-                    .filter(p -> p.getId().equals(command.productId()))
-                    .findFirst()
-                    .get(); // 이미 검증됐으므로 get() 가능
-
-            product.deductStock(command.quantity()); // 이 시점에만 상태 변경
+        for (ProductCommand.DeductStock command : commands) {
+            Product product = command.product();
+            product.deductStock(command.quantity());
         }
 
         return true;

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -42,7 +42,7 @@ public class ProductService {
     }
 
     public List<Product> findAllValidProductsOrThrow(List<Long> productIds) {
-        List<Product> products = productRepository.findAllByIds(productIds);
+        List<Product> products = productRepository.findAllValidWithPessimisticLock(productIds);
 
         Set<Long> foundIds = products.stream()
                 .map(Product::getId)

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -29,11 +29,6 @@ public class ProductService {
         return productRepository.findById(productId);
     }
 
-    //todo: 제거 예정
-    public void increaseLikeCountOld(final Product product) {
-        product.increaseLikeCount();
-    }
-
     public void increaseLikeCount(final Product product) {
         int processCount = productRepository.updateLikeCountById(product.getId());
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -30,8 +29,13 @@ public class ProductService {
         return productRepository.findById(productId);
     }
 
-    public void increaseLikeCount(final Product product) {
+    //todo: 제거 예정
+    public void increaseLikeCountOld(final Product product) {
         product.increaseLikeCount();
+    }
+
+    public void increaseLikeCount(final Product product) {
+        int processCount = productRepository.updateLikeCountById(product.getId());
     }
 
     public void decreaseLikeCount(final Product product) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -44,17 +44,21 @@ public class ProductService {
         return productRepository.findAllByIds(productIds);
     }
 
-    public List<Product> findAllValidProducts(Set<Long> productIds) {
-        final List<Product> products = productRepository.findAllByIds(productIds.stream().toList());
-        final Set<Long> foundIds = products.stream().map(Product::getId).collect(Collectors.toSet());
+    public List<Product> findAllValidProductsOrThrow(Set<Long> productIds) {
+        List<Product> products = productRepository.findAllByIds(productIds.stream().toList());
+
+        Set<Long> foundIds = products.stream()
+                .map(Product::getId)
+                .collect(Collectors.toSet());
 
         if (!foundIds.containsAll(productIds)) {
-            return Collections.emptyList();
+            throw new CoreException(ErrorType.NOT_FOUND, "존재하지 않는 상품입니다.");
         }
+
         return products;
     }
 
-    public boolean deductStock(List<ProductCommand.CheckStock> commands) {
+    /*public boolean deductStock(List<ProductCommand.CheckStock> commands) {
         Set<Long> productIds = commands.stream().map(ProductCommand.CheckStock::productId).collect(Collectors.toSet());
         List<Product> products = productRepository.findAllByIds(productIds.stream().toList());
 
@@ -72,6 +76,38 @@ public class ProductService {
                 return false;
             }
         }
+        return true;
+    }*/
+    public boolean deductStock(List<ProductCommand.CheckStock> commands) {
+        Set<Long> productIds = commands.stream()
+                .map(ProductCommand.CheckStock::productId)
+                .collect(Collectors.toSet());
+
+        List<Product> products = productRepository.findAllByIds(productIds.stream().toList());
+
+        // 1. 재고 검증 (재고 수량 변경 없이)
+        for (ProductCommand.CheckStock command : commands) {
+            Product product = products.stream()
+                    .filter(p -> p.getId().equals(command.productId()))
+                    .findFirst()
+                    .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품 없음: " + command.productId()));
+
+            if (command.quantity().isGreaterThan(product.getStockQuantity())) {
+                product.markSoldOut(); // 일시품절 처리 todo: 비동기 처리 필요
+                return false;
+            }
+        }
+
+        // 2. 재고 차감 (모든 검증 통과 후)
+        for (ProductCommand.CheckStock command : commands) {
+            Product product = products.stream()
+                    .filter(p -> p.getId().equals(command.productId()))
+                    .findFirst()
+                    .get(); // 이미 검증됐으므로 get() 가능
+
+            product.deductStock(command.quantity()); // 이 시점에만 상태 변경
+        }
+
         return true;
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -29,7 +29,7 @@ public class ProductService {
         return productRepository.findById(productId);
     }
 
-    public void increaseLikeCount(final Product product) {
+    public void increaseLikeCountAtomically(final Product product) {
         int processCount = productRepository.updateLikeCountById(product.getId());
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -34,7 +34,7 @@ public class ProductService {
     }
 
     public void decreaseLikeCount(final Product product) {
-        product.decreaseLikeCount();
+        productRepository.decreaseLikeCountById(product.getId());
     }
 
     public List<Product> getProducts(List<Long> productIds) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -32,12 +32,10 @@ public class ProductService {
 
     public void increaseLikeCount(final Product product) {
         product.increaseLikeCount();
-        productRepository.save(product);
     }
 
     public void decreaseLikeCount(final Product product) {
         product.decreaseLikeCount();
-        productRepository.save(product);
     }
 
     public List<Product> getProducts(List<Long> productIds) {

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponJpaRepository extends JpaRepository<Coupon,Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -16,4 +16,9 @@ public class CouponRepositoryImpl implements CouponRepository {
     public List<Coupon> findAllById(List<Long> userCouponIds) {
         return couponJpaRepository.findAllById(userCouponIds);
     }
+
+    @Override
+    public Coupon save(Coupon coupon) {
+        return couponJpaRepository.save(coupon);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.Coupon;
+import com.loopers.domain.coupon.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class CouponRepositoryImpl implements CouponRepository {
+    final CouponJpaRepository couponJpaRepository;
+
+    @Override
+    public List<Coupon> findAllById(List<Long> userCouponIds) {
+        return couponJpaRepository.findAllById(userCouponIds);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.UserCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserCouponJpaRepository extends JpaRepository<UserCoupon,Long> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.UserCoupon;
+import com.loopers.domain.coupon.UserCouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class UserCouponRepositoryImpl implements UserCouponRepository {
+    final UserCouponJpaRepository userCouponJpaRepository;
+
+    @Override
+    public List<UserCoupon> findAllById(List<Long> userCouponIds) {
+        return userCouponJpaRepository.findAllById(userCouponIds);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponRepositoryImpl.java
@@ -16,4 +16,9 @@ public class UserCouponRepositoryImpl implements UserCouponRepository {
     public List<UserCoupon> findAllById(List<Long> userCouponIds) {
         return userCouponJpaRepository.findAllById(userCouponIds);
     }
+
+    @Override
+    public UserCoupon save(UserCoupon userCoupon) {
+        return userCouponJpaRepository.save(userCoupon);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponRepositoryImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Repository
@@ -20,5 +21,10 @@ public class UserCouponRepositoryImpl implements UserCouponRepository {
     @Override
     public UserCoupon save(UserCoupon userCoupon) {
         return userCouponJpaRepository.save(userCoupon);
+    }
+
+    @Override
+    public Optional<UserCoupon> findById(Long couponId) {
+        return userCouponJpaRepository.findById(couponId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeHistoryJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeHistoryJpaRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface LikeHistoryJpaRepository extends JpaRepository<LikeHistory, Long> {
     Optional<LikeHistory> findByUserIdAndProductId(Long userId, Long productId);
     Page<LikeHistory> findByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
+    int deleteByUserIdAndProductId(Long userId, Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeHistoryRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeHistoryRepositoryImpl.java
@@ -34,4 +34,14 @@ public class LikeHistoryRepositoryImpl implements LikeHistoryRepository {
     public Page<LikeHistory> findByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable) {
         return likeHistoryJpaRepository.findByUserIdAndDeletedAtIsNull(userId, pageable);
     }
+
+    @Override
+    public int deleteByUserIdAndProductId(Long userId, Long productId) {
+        return likeHistoryJpaRepository.deleteByUserIdAndProductId(userId, productId);
+    }
+
+    @Override
+    public void deleteAll() {
+        likeHistoryJpaRepository.deleteAll();
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderJpaRepository.java
@@ -5,10 +5,16 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByOrderRequestId(String orderRequestId);
 
     @EntityGraph(attributePaths = "orderLines")
     Optional<Order> findById(Long id);
+
+    @Query("SELECT SUM(o.paymentAmount.amount) FROM Order o WHERE o.userId = :userId")
+    Optional<Long> findTotalPaymentAmountByUserId(@Param("userId") Long userId);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/order/OrderRepositoryImpl.java
@@ -3,6 +3,9 @@ package com.loopers.infrastructure.order;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.order.OrderRepository;
 import java.util.Optional;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -25,5 +28,11 @@ public class OrderRepositoryImpl implements OrderRepository {
     @Override
     public Optional<Order> findByIdWithOrderLines(Long id) {
         return orderJpaRepository.findById(id);
+    }
+
+    @Override
+    public Long findTotalPaymentAmountByUserId(Long userId) {
+        return orderJpaRepository.findTotalPaymentAmountByUserId(userId)
+                .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "사용자의 결제 금액을 찾을 수 없습니다. userId: " + userId));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentJpaRepository.java
@@ -3,5 +3,8 @@ package com.loopers.infrastructure.payment;
 import com.loopers.domain.payment.Payment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PaymentJpaRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByOrderId(Long orderId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/payment/PaymentRepositoryImpl.java
@@ -5,6 +5,8 @@ import com.loopers.domain.payment.PaymentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Repository
 public class PaymentRepositoryImpl implements PaymentRepository {
@@ -14,5 +16,15 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     @Override
     public Payment save(Payment payment) {
         return paymentJpaRepository.save(payment);
+    }
+
+    @Override
+    public Optional<Payment> findById(Long paymentId) {
+        return paymentJpaRepository.findById(paymentId);
+    }
+
+    @Override
+    public Optional<Payment> findByOrderId(Long orderId) {
+        return paymentJpaRepository.findByOrderId(orderId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,7 +1,9 @@
 package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.Point;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,4 +14,7 @@ public interface PointJpaRepository extends JpaRepository<Point, Long> {
 
     Optional<Point> findByUserId(Long userId);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Point p WHERE p.userId = :userId")
+    Optional<Point> findByUserIdWithLock(@Param("userId") Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -27,4 +27,9 @@ public class PointRepositoryImpl implements PointRepository {
     public Point save(Point point) {
         return pointJpaRepository.save(point);
     }
+
+    @Override
+    public Optional<Point> findByUserIdWithLock(Long userId) {
+        return pointJpaRepository.findByUserIdWithLock(userId);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,7 +1,9 @@
 package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.Product;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +20,8 @@ public interface ProductJpaRepository extends JpaRepository<Product, Long>, Prod
     @Modifying
     @Query("update Product p set p.likeCount = p.likeCount - 1 where p.id = :productId and p.likeCount > 0")
     int decreaseLikeCountById(@Param("productId") Long productId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Product p WHERE p.id IN :ids AND p.status = 'AVAILABLE'")
+    List<Product> findAllValidWithPessimisticLock(@Param("ids") List<Long> ids);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -14,4 +14,8 @@ public interface ProductJpaRepository extends JpaRepository<Product, Long>, Prod
     @Modifying
     @Query("UPDATE Product p SET p.likeCount = p.likeCount + 1 WHERE p.id = :productId")
     int updateLikeCountById(@Param("productId") Long productId);
+
+    @Modifying
+    @Query("update Product p set p.likeCount = p.likeCount - 1 where p.id = :productId and p.likeCount > 0")
+    int decreaseLikeCountById(@Param("productId") Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -3,6 +3,9 @@ package com.loopers.infrastructure.product;
 import com.loopers.domain.product.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProductJpaRepository extends JpaRepository<Product, Long>, ProductDslRepository  {
+import java.util.List;
+import java.util.Set;
+
+public interface ProductJpaRepository extends JpaRepository<Product, Long>, ProductDslRepository {
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -2,10 +2,16 @@ package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Set;
 
 public interface ProductJpaRepository extends JpaRepository<Product, Long>, ProductDslRepository {
 
+    @Modifying
+    @Query("UPDATE Product p SET p.likeCount = p.likeCount + 1 WHERE p.id = :productId")
+    int updateLikeCountById(@Param("productId") Long productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.loopers.infrastructure.product;
 import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductListProjection;
 import com.loopers.domain.product.ProductRepository;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -51,5 +52,10 @@ public class ProductRepositoryImpl implements ProductRepository {
     @Override
     public List<Product> findAllByIds(List<Long> productIds) {
         return productJpaRepository.findAllById(productIds);
+    }
+
+    @Override
+    public int updateLikeCountById(Long id) {
+        return productJpaRepository.updateLikeCountById(id);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -58,4 +58,9 @@ public class ProductRepositoryImpl implements ProductRepository {
     public int updateLikeCountById(Long id) {
         return productJpaRepository.updateLikeCountById(id);
     }
+
+    @Override
+    public int decreaseLikeCountById(Long id) {
+        return productJpaRepository.decreaseLikeCountById(id);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -63,4 +63,9 @@ public class ProductRepositoryImpl implements ProductRepository {
     public int decreaseLikeCountById(Long id) {
         return productJpaRepository.decreaseLikeCountById(id);
     }
+
+    @Override
+    public List<Product> findAllValidWithPessimisticLock(List<Long> productIds) {
+        return productJpaRepository.findAllValidWithPessimisticLock(productIds);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -50,6 +50,6 @@ public class ProductRepositoryImpl implements ProductRepository {
 
     @Override
     public List<Product> findAllByIds(List<Long> productIds) {
-        return productJpaRepository.findAllById(productIds.stream().toList());
+        return productJpaRepository.findAllById(productIds);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/support/error/CoreException.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/error/CoreException.java
@@ -1,5 +1,6 @@
 package com.loopers.support.error;
 
+import com.loopers.domain.payment.PaymentFailureReason;
 import lombok.Getter;
 
 @Getter

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeUseCaseConcurrentTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeUseCaseConcurrentTest.java
@@ -1,0 +1,107 @@
+package com.loopers.application.like;
+
+import com.loopers.domain.commonvo.Quantity;
+import com.loopers.domain.like.LikeHistoryRepository;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.domain.product.ProductStatus;
+import com.loopers.testcontainers.MySqlTestContainersConfig;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@SpringBootTest
+@Import(MySqlTestContainersConfig.class)
+class LikeUseCaseConcurrentTest {
+
+    @Autowired
+    private LikeUseCase likeUseCase;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private LikeHistoryRepository likeHistoryRepository;
+
+    private static final int THREAD_COUNT = 20;
+    private static Long productId;
+
+    @BeforeAll
+    static void setUpOnce(@Autowired ProductRepository productRepository,
+                          @Autowired LikeHistoryRepository likeHistoryRepository) {
+        likeHistoryRepository.deleteAll();
+
+        Long brandId = 1L;
+        Product product = Product.from(
+                "상품1", 1000L, ProductStatus.AVAILABLE,
+                0, Quantity.of(10), LocalDate.now().minusDays(1), brandId);
+        productRepository.save(product);
+        productId = product.getId();
+    }
+
+    @Test
+    @DisplayName("동시 요청 시 성공/실패 요청을 기록하고 likeCount 검증")
+    void likeCountConcurrencyTest_withSuccessFailLogging() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(50);
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failCount = new AtomicInteger();
+        AtomicInteger duplicatedCount = new AtomicInteger();
+
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            final long userId = i + 1; // 100명 유저
+            executorService.submit(() -> {
+                try {
+                    LikeResult.LikeRegisterResult result = likeUseCase.register(userId, productId);
+
+                    if (result.isDuplicatedRequest()) {
+                        duplicatedCount.incrementAndGet();
+                        System.out.println("[중복] userId = " + userId);
+                        failCount.incrementAndGet();
+                    } else {
+                        successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                    System.err.println("[예외 발생] userId = " + userId + ", message = " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+        executorService.awaitTermination(10, TimeUnit.SECONDS);
+
+        Product product = productRepository.findById(productId).orElseThrow();
+
+        // 결과 출력
+        System.out.println("🟢 성공한 요청 수: " + successCount.get());
+        System.out.println("🔴 실패한 요청 수: " + failCount.get());
+        System.out.println("🎯 최종 likeCount: " + product.getLikeCount().getValue());
+        System.out.println("🔁 중복 요청 수: " + duplicatedCount.get());
+
+        // 검증
+        assertThat(product.getLikeCount().getValue()).isEqualTo(successCount.get());
+        assertThat(successCount.get() + failCount.get()).isEqualTo(THREAD_COUNT);
+    }
+
+
+
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeUseCaseConcurrentTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeUseCaseConcurrentTest.java
@@ -6,9 +6,12 @@ import com.loopers.domain.product.Product;
 import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.product.ProductStatus;
 import com.loopers.testcontainers.MySqlTestContainersConfig;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -25,6 +28,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 @SpringBootTest
 @Import(MySqlTestContainersConfig.class)
 class LikeUseCaseConcurrentTest {
+    private static final Logger log = LoggerFactory.getLogger(LikeUseCaseConcurrentTest.class);
 
     @Autowired
     private LikeUseCase likeUseCase;
@@ -114,6 +118,89 @@ class LikeUseCaseConcurrentTest {
                     .as("최종 likeCount는 요청 수와 같아야 함")
                     .isEqualTo(threadCount);
         });
+
+        log.info("🟢 성공 요청 수: {}", totalSuccess);
+        log.info("🔁 중복 요청 수: {}", totalDuplicated);
+        log.info("🔴 예외 발생 수: {}", totalException);
+        log.info("❤️ 최종 likeCount: {}", product.getLikeCount().getValue());
     }
+
+    @DisplayName("하나의 상품에 대해 50명 사용자가 동시에 좋아요 해제 요청 시, likeCount는 1씩 정확히 감소해야 한다.")
+    @Test
+    void testLikeCountConcurrentRemoveRequests() throws Exception {
+        // given: 50명 유저가 먼저 좋아요 등록
+        int userCount = 50;
+        for (int i = 0; i < userCount; i++) {
+            long userId = i + 1;
+            likeUseCase.register(userId, productId);
+        }
+
+        Product likedProduct = productRepository.findById(productId).orElseThrow();
+        assertThat(likedProduct.getLikeCount().getValue()).isEqualTo(userCount);
+
+        // when: 동시에 좋아요 해제 요청
+        ExecutorService executorService = Executors.newFixedThreadPool(20);
+        List<CompletableFuture<Boolean>> tasks = new ArrayList<>(userCount);
+
+        AtomicInteger exceptionCount = new AtomicInteger(0);
+        AtomicInteger duplicatedCount = new AtomicInteger(0);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int i = 0; i < userCount; i++) {
+            final long userId = i + 1;
+            tasks.add(
+                    CompletableFuture.supplyAsync(() -> {
+                        try {
+                            LikeResult.LikeRemoveResult result = likeUseCase.remove(userId, productId);
+                            if (result.isDuplicatedRequest()) {
+                                duplicatedCount.incrementAndGet();
+                                return false;
+                            } else {
+                                successCount.incrementAndGet();
+                                return true;
+                            }
+                        } catch (Exception e) {
+                            exceptionCount.incrementAndGet();
+                            return false;
+                        }
+                    }, executorService)
+            );
+        }
+
+        // then
+        CompletableFuture.allOf(tasks.toArray(new CompletableFuture[0])).join();
+        executorService.shutdown();
+        executorService.awaitTermination(10, TimeUnit.SECONDS);
+
+        int totalSuccess = successCount.get();
+        int totalDuplicated = duplicatedCount.get();
+        int totalException = exceptionCount.get();
+
+        Product finalProduct = productRepository.findById(productId).orElseThrow();
+
+        assertSoftly(softly -> {
+            softly.assertThat(totalException)
+                    .as("예외 발생 횟수 검증")
+                    .isEqualTo(0);
+
+            softly.assertThat(totalDuplicated)
+                    .as("중복 요청 수 검증")
+                    .isEqualTo(0); // 유저 당 1번 요청이므로 중복 없어야 함
+
+            softly.assertThat(totalSuccess)
+                    .as("성공한 해제 요청 수 검증")
+                    .isEqualTo(userCount);
+
+            softly.assertThat(finalProduct.getLikeCount().getValue())
+                    .as("최종 likeCount는 0이어야 함")
+                    .isEqualTo(0);
+        });
+
+        log.info("🟢 성공 요청 수: {}", totalSuccess);
+        log.info("🔁 중복 요청 수: {}", totalDuplicated);
+        log.info("🔴 예외 발생 수: {}", totalException);
+        log.info("❤️ 최종 likeCount: {}", finalProduct.getLikeCount().getValue());
+    }
+
 }
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeUseCaseConcurrentTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeUseCaseConcurrentTest.java
@@ -7,7 +7,6 @@ import com.loopers.domain.product.ProductRepository;
 import com.loopers.domain.product.ProductStatus;
 import com.loopers.testcontainers.MySqlTestContainersConfig;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,7 +51,7 @@ class LikeUseCaseConcurrentTest {
         productId = product.getId();
     }
 
-    @DisplayName("하나의 상품에 여러 명이 동시에 좋아요 요청 시, 좋아요 수는 정확히 1씩 증가하고 요청 성공/실패가 구분되어야 한다.")
+    @DisplayName("하나의 상품에 각 50명 사용자가 동시에 좋아요 요청 시, 좋아요 수는 1씩 증가하고 중복 요청은 없어야한다.")
     @Test
     void testLikeCountConcurrentRequestsWithSingleLikePerUser() throws Exception {
         // assign

--- a/apps/commerce-api/src/test/java/com/loopers/application/like/LikeUseCaseIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/like/LikeUseCaseIntegrationTest.java
@@ -83,10 +83,12 @@ class LikeUseCaseIntegrationTest {
         void register_firstTimeLike_increasesLikeCount() {
             Optional<LikeHistory> foundLikeHistory = likeHistoryRepository.findByUserIdAndProductId(userId, productId);
             assertThat(foundLikeHistory).isEmpty();
+
             Product foundProduct = productRepository.findById(productId).orElseThrow();
             int beforeLikeCount = 0;
             assertThat(foundProduct.getLikeCount().getValue()).isEqualTo(beforeLikeCount);
 
+            // Act
             LikeResult.LikeRegisterResult actual = sut.register(userId, productId);
 
             // Assert
@@ -102,22 +104,26 @@ class LikeUseCaseIntegrationTest {
         @DisplayName("이미 좋아요한 경우 중복요청은 참이고, likeCount는 증가하지 않는다")
         void register_duplicateLike_doesNotIncreaseLikeCount() {
             // Arrange
-            sut.register(userId, productId);
+            sut.register(userId, productId); //좋아요 등록 이미한 상태로 만듦
+
             Optional<LikeHistory> foundLikeHistory = likeHistoryRepository.findByUserIdAndProductId(userId, productId);
             Optional<Product> foundProduct = productRepository.findById(productId);
             assertThat(foundLikeHistory).isPresent();
+
             int beforeLikeCount = 1;
             assertThat(foundProduct.get().getLikeCount().getValue()).isEqualTo(beforeLikeCount);
 
             // Act
-            LikeResult.LikeRegisterResult result = sut.register(userId, productId);
+            LikeResult.LikeRegisterResult actual = sut.register(userId, productId);
 
             // Assert
             Product updated = productRepository.findById(productId).orElseThrow();
 
             assertAll(
-                    () -> assertThat(result).isNotNull(),
-                    () -> assertThat(result.isDuplicatedRequest()).isTrue(),
+                    () -> assertThat(actual).isNotNull(),
+                    () -> assertThat(actual.isDuplicatedRequest()).isTrue(),
+                    () ->assertThat(actual.userId()).isEqualTo(userId),
+                    () -> assertThat(actual.productId()).isEqualTo(productId),
                     () -> assertThat(updated.getLikeCount().getValue()).isEqualTo(beforeLikeCount)
             );
         }

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderUseCaseConcurrentTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderUseCaseConcurrentTest.java
@@ -1,0 +1,113 @@
+package com.loopers.application.order;
+
+import com.loopers.domain.coupon.UserCouponRepository;
+import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.testcontainers.MySqlTestContainersConfig;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@SpringBootTest
+@Import(MySqlTestContainersConfig.class)
+@Sql(scripts = "/sql/coupon-concurrent-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class CouponUseCaseConcurrencyTest {
+
+    private static final Logger log = LoggerFactory.getLogger(CouponUseCaseConcurrencyTest.class);
+
+    @Autowired
+    private OrderUseCase orderUseCase;
+
+    @Autowired
+    private UserCouponRepository userCouponRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private static final int THREAD_COUNT = 50;
+    private static final Long USER_ID = 1L;
+    private static final String ORDER_REQUEST_PREFIX = "order-coupon-";
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @Test
+    @DisplayName("동시에 동일한 쿠폰 사용 시, 단 1명만 성공하고 나머지는 실패한다")
+    void onlyOneShouldSucceedWhenCouponUsedConcurrently() throws Exception {
+        // Arrange
+        Long couponId = 1L; // 미리 발급된 user_coupon.id
+        Long productId = 1L;
+        int quantity = 1;
+
+        ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+        List<CompletableFuture<Boolean>> futures = new ArrayList<>();
+
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            final String orderRequestId = ORDER_REQUEST_PREFIX + i;
+            futures.add(CompletableFuture.supplyAsync(() -> {
+                try {
+                    OrderInfo.ItemInfo item = new OrderInfo.ItemInfo(productId, quantity);
+                    List<Long> couponIds = List.of(couponId);
+                    orderUseCase.order(USER_ID, orderRequestId, List.of(item), couponIds);
+                    return true;
+                } catch (Exception e) {
+//                    log.warn("❌ 실패: {}", e.getMessage());
+                    return false;
+                }
+            }, executor));
+        }
+
+        List<Boolean> results = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .thenApply(v -> futures.stream().map(CompletableFuture::join).toList())
+                .get();
+
+        long successCount = results.stream().filter(Boolean::booleanValue).count();
+        long failureCount = THREAD_COUNT - successCount;
+
+        // Assert
+        assertSoftly(softly -> {
+            softly.assertThat(successCount)
+                    .as("쿠폰 성공 사용 건수")
+                    .isEqualTo(1);
+
+            softly.assertThat(failureCount)
+                    .as("쿠폰 실패 사용 건수")
+                    .isEqualTo(THREAD_COUNT - 1);
+
+            softly.assertThat(userCouponRepository.findById(couponId).orElseThrow().isUsed())
+                    .as("쿠폰 사용 여부")
+                    .isTrue();
+        });
+
+        log.info("✅ 성공: {}", successCount);
+        log.info("❌ 실패: {}", failureCount);
+    }
+}
+

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderUseCaseIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderUseCaseIntegrationTest.java
@@ -6,6 +6,7 @@ import com.loopers.domain.brand.BrandRepository;
 import com.loopers.domain.brand.BrandStatus;
 import com.loopers.domain.commonvo.Money;
 import com.loopers.domain.commonvo.Quantity;
+import com.loopers.domain.coupon.*;
 import com.loopers.domain.order.*;
 import com.loopers.domain.order.Order;
 import com.loopers.domain.point.Point;
@@ -22,7 +23,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.jdbc.Sql;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +50,10 @@ class OrderUseCaseIntegrationTest {
     private BrandRepository brandRepository;
     @MockitoSpyBean
     private PointRepository pointRepository;
-
+    @MockitoSpyBean
+    private UserCouponRepository userCouponRepository;
+    @MockitoSpyBean
+    private CouponRepository couponRepository;
 
     private static final Long USER_ID = 1L;
     private static final String ORDER_REQUEST_ID = "order-123";
@@ -164,5 +170,149 @@ class OrderUseCaseIntegrationTest {
                     () -> assertThat(order.calculateOrderAmount()).isEqualTo(Money.of(8000L))
             );
         }
+
+        @Test
+        @DisplayName("쿠폰이 적용되면, Order에 할인 금액이 반영된다.")
+        void placeOrder_appliesCouponDiscount() {
+            // arrange
+            List<OrderInfo.ItemInfo> items = List.of(
+                    new OrderInfo.ItemInfo(productId1, 2) // 2 * 1000 = 2000
+            );
+
+            // 쿠폰 생성 (10% 할인)
+            DiscountPolicy discountPolicy = DiscountPolicy.of(DiscountType.RATE, new BigDecimal("0.100"));
+            Coupon coupon = couponRepository.save(
+                    Coupon.create("10% 할인 쿠폰", discountPolicy, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1))
+            );
+
+            Money originalOrderAmount = productRepository.findById(productId1).orElseThrow()
+                    .getPrice().multiply(Quantity.of(2));
+            assertThat(originalOrderAmount).isEqualTo(Money.of(2000L)); // 사전 검증
+
+            // 유저 쿠폰 발급
+            UserCoupon userCoupon = userCouponRepository.save(UserCoupon.create(USER_ID, coupon));
+            List<Long> userCouponIds = List.of(userCoupon.getId());
+
+            // act
+            OrderResult.OrderRequestResult result = sut.order(USER_ID, ORDER_REQUEST_ID, items, userCouponIds);
+
+            // assert
+            Order order = orderRepository.findByIdWithOrderLines(result.orderId()).orElseThrow();
+            Money expectedTotal = Money.of(2000L);
+            Money expectedDiscount = Money.of(200L);  // 10% of 2000
+            Money expectedPayment = Money.of(1800L);  // 2000 - 200
+
+            assertAll(
+                    () -> assertThat(order.getTotalAmount()).isEqualTo(expectedTotal),
+                    () -> assertThat(order.getDiscountAmount()).isEqualTo(expectedDiscount),
+                    () -> assertThat(order.getPaymentAmount()).isEqualTo(expectedPayment),
+                    () -> assertThat(order.getStatus()).isEqualTo(OrderStatus.PENDING)
+            );
+        }
+
+        @Test
+        @DisplayName("정액 할인 쿠폰이 적용되면, Order에 할인 금액이 반영된다.")
+        void placeOrder_appliesFixedAmountCouponDiscount() {
+            // arrange
+            List<OrderInfo.ItemInfo> items = List.of(
+                    new OrderInfo.ItemInfo(productId1, 2) // 2 * 1000 = 2000
+            );
+
+            // 정액 쿠폰 생성 (1,500원 할인)
+            DiscountPolicy discountPolicy = DiscountPolicy.of(DiscountType.FIXED_AMOUNT, new BigDecimal("1500"));
+            Coupon coupon = couponRepository.save(
+                    Coupon.create("1,500원 할인 쿠폰", discountPolicy, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1))
+            );
+
+            Money originalOrderAmount = productRepository.findById(productId1).orElseThrow()
+                    .getPrice().multiply(Quantity.of(2));
+            assertThat(originalOrderAmount).isEqualTo(Money.of(2000L)); // 사전 검증
+
+            // 유저 쿠폰 발급
+            UserCoupon userCoupon = userCouponRepository.save(UserCoupon.create(USER_ID, coupon));
+            List<Long> userCouponIds = List.of(userCoupon.getId());
+
+            // act
+            OrderResult.OrderRequestResult result = sut.order(USER_ID, ORDER_REQUEST_ID, items, userCouponIds);
+
+            // assert
+            Order order = orderRepository.findByIdWithOrderLines(result.orderId()).orElseThrow();
+            Money expectedTotal = Money.of(2000L);
+            Money expectedDiscount = Money.of(1500L);
+            Money expectedPayment = Money.of(500L); // 2000 - 1500
+
+            assertAll(
+                    () -> assertThat(order.getTotalAmount()).isEqualTo(expectedTotal),
+                    () -> assertThat(order.getDiscountAmount()).isEqualTo(expectedDiscount),
+                    () -> assertThat(order.getPaymentAmount()).isEqualTo(expectedPayment),
+                    () -> assertThat(order.getStatus()).isEqualTo(OrderStatus.PENDING)
+            );
+        }
+
+        @Test
+        @DisplayName("기간이 만료된 쿠폰을 사용하면 주문은 실패해야 한다.")
+        void placeOrder_shouldFailIfCouponExpired() {
+            // arrange
+            List<OrderInfo.ItemInfo> items = List.of(
+                    new OrderInfo.ItemInfo(productId1, 2) // 2000원
+            );
+
+            // 만료된 쿠폰 생성 (endAt가 과거)
+            DiscountPolicy discountPolicy = DiscountPolicy.of(DiscountType.FIXED_AMOUNT, new BigDecimal("1000"));
+            Coupon expiredCoupon = couponRepository.save(
+                    Coupon.create("만료 쿠폰", discountPolicy, LocalDate.now().minusDays(10), LocalDate.now().minusDays(5))
+            );
+
+            // 유저 쿠폰 발급
+            UserCoupon userCoupon = userCouponRepository.save(UserCoupon.create(USER_ID, expiredCoupon));
+            List<Long> userCouponIds = List.of(userCoupon.getId());
+
+            // act & assert
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                sut.order(USER_ID, ORDER_REQUEST_ID, items, userCouponIds);
+            });
+
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+            assertThat(exception.getMessage()).contains("사용할 수 없는 쿠폰");
+
+            Order order = orderRepository.findByOrderRequestId(ORDER_REQUEST_ID).orElse(null);
+            assertThat(order).isNotNull();
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.VALIDATION_FAILED);
+        }
+
+        @Test
+        @DisplayName("이미 사용된 쿠폰을 사용하면 주문은 실패해야 한다.")
+        void placeOrder_shouldFailIfCouponAlreadyUsed() {
+            // arrange
+            List<OrderInfo.ItemInfo> items = List.of(
+                    new OrderInfo.ItemInfo(productId1, 2) // 2000원
+            );
+
+            // 유효한 쿠폰 생성
+            DiscountPolicy discountPolicy = DiscountPolicy.of(DiscountType.FIXED_AMOUNT, new BigDecimal("1000"));
+            Coupon validCoupon = couponRepository.save(
+                    Coupon.create("1,000원 쿠폰", discountPolicy, LocalDate.now().minusDays(1), LocalDate.now().plusDays(1))
+            );
+
+            // 유저 쿠폰 생성 및 사용 처리
+            UserCoupon userCoupon = userCouponRepository.save(UserCoupon.create(USER_ID, validCoupon));
+            userCoupon.markUsed(); // 사용 처리
+            userCoupon = userCouponRepository.save(userCoupon);
+            assertThat(userCoupon.isUsed()).isTrue();
+
+             List<Long> userCouponIds = List.of(userCoupon.getId());
+
+            // act & assert
+             CoreException exception = assertThrows(CoreException.class, () -> {
+                sut.order(USER_ID, ORDER_REQUEST_ID, items, userCouponIds);
+            });
+
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+
+            Order order = orderRepository.findByOrderRequestId(ORDER_REQUEST_ID).orElse(null);
+            assertThat(order).isNotNull();
+            assertThat(order.getStatus()).isEqualTo(OrderStatus.VALIDATION_FAILED);
+        }
+
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderUseCaseIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderUseCaseIntegrationTest.java
@@ -82,7 +82,7 @@ class OrderUseCaseIntegrationTest {
 
         @Test
         @DisplayName("상품 유효성 검증에 실패하더라도, 주문은 VALIDATION_FAILED 상태로 저장한다.")
-        void createOrder_shouldPersistOrderEvenIfProductValidationFails22() {
+        void createOrder_shouldPersistOrderEvenIfProductValidationFails() {
             // arrange
             List<OrderInfo.ItemInfo> invalidItems = List.of(
                     new OrderInfo.ItemInfo(999999L, 1)
@@ -94,7 +94,7 @@ class OrderUseCaseIntegrationTest {
             });
 
             // assert: 예외 검증
-            assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
 
             // assert: 예외 발생했지만 주문은 저장되었는지 확인
             Order actual = orderRepository.findByOrderRequestId(ORDER_REQUEST_ID).orElse(null);

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderUseCaseIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderUseCaseIntegrationTest.java
@@ -273,7 +273,6 @@ class OrderUseCaseIntegrationTest {
             });
 
             assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
-            assertThat(exception.getMessage()).contains("사용할 수 없는 쿠폰");
 
             Order order = orderRepository.findByOrderRequestId(ORDER_REQUEST_ID).orElse(null);
             assertThat(order).isNotNull();

--- a/apps/commerce-api/src/test/java/com/loopers/application/order/OrderUseCaseIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/order/OrderUseCaseIntegrationTest.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,9 +89,11 @@ class OrderUseCaseIntegrationTest {
                     new OrderInfo.ItemInfo(999999L, 1)
             );
 
+            List<Long> userCouponIds = Collections.emptyList();
+
             // act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                sut.order(USER_ID, ORDER_REQUEST_ID, invalidItems);
+                sut.order(USER_ID, ORDER_REQUEST_ID, invalidItems, userCouponIds);
             });
 
             // assert: 예외 검증
@@ -117,9 +120,11 @@ class OrderUseCaseIntegrationTest {
             Money orderTotalAmount = productPrice.multiply(Quantity.of(quantity));
             assertThat(userBalance.isLessThan(orderTotalAmount)).isTrue();
 
+            List<Long> userCouponIds = Collections.emptyList();
+
             // Act
             CoreException exception = assertThrows(CoreException.class, () -> {
-                sut.order(USER_ID, ORDER_REQUEST_ID, items);
+                sut.order(USER_ID, ORDER_REQUEST_ID, items, userCouponIds);
             });
 
             // Assert
@@ -145,7 +150,8 @@ class OrderUseCaseIntegrationTest {
             );
 
             // act
-            OrderResult.OrderRequestResult result = sut.order(USER_ID, ORDER_REQUEST_ID, items);
+            List<Long> userCouponIds = Collections.emptyList();
+            OrderResult.OrderRequestResult result = sut.order(USER_ID, ORDER_REQUEST_ID, items, userCouponIds);
 
             // assert
             Order order = orderRepository.findByIdWithOrderLines(result.orderId()).orElseThrow();

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentUseCaseConCurrentTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentUseCaseConCurrentTest.java
@@ -1,0 +1,114 @@
+package com.loopers.application.payment;
+
+import com.loopers.domain.commonvo.Money;
+import com.loopers.domain.commonvo.Quantity;
+import com.loopers.domain.order.OrderRepository;
+import com.loopers.domain.payment.PaymentMethod;
+import com.loopers.domain.point.Point;
+import com.loopers.domain.point.PointRepository;
+import com.loopers.domain.product.ProductRepository;
+import com.loopers.testcontainers.MySqlTestContainersConfig;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@SpringBootTest
+@Import(MySqlTestContainersConfig.class)
+@Sql(scripts = "/sql/order-concurrent-data.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
+class PaymentUseCaseConcurrencyTest {
+    private static final Logger log = LoggerFactory.getLogger(PaymentUseCaseConcurrencyTest.class);
+
+    @Autowired
+    private PaymentUseCase paymentUseCase;
+
+    @Autowired
+    private PointRepository pointRepository;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    private static final int THREAD_COUNT = 20;
+    private static final Long USER_ID = 1L;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("1명의 사용자가 서로 다른 주문 20건을 동시에 결제 시도하면, 포인트와 재고가 정확히 차감된다")
+    @Test
+    void concurrentPaymentWithDifferentOrders() throws InterruptedException, ExecutionException {
+        //arrange 검증
+        Money beforeUserBalance = pointRepository.findByUserId(USER_ID).orElseThrow()
+                .balance();
+        Long totalPaymentAmount = orderRepository.findTotalPaymentAmountByUserId(USER_ID);
+        assertThat(beforeUserBalance.getAmount()).isEqualTo(100_000);
+        assertThat(totalPaymentAmount).isEqualTo(20_000);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+        List<CompletableFuture<Boolean>> futures = new ArrayList<>();
+
+        for (int i = 1; i <= THREAD_COUNT; i++) {
+            final long orderId = 1000L + i; // 1001 ~ 1020
+            CompletableFuture<Boolean> future = CompletableFuture.supplyAsync(() -> {
+                try {
+                    PaymentInfo.Pay payInfo = new PaymentInfo.Pay(orderId, PaymentMethod.POINT);
+                    paymentUseCase.pay(USER_ID, payInfo);
+                    return true;
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return false;
+                }
+            }, executorService);
+            futures.add(future);
+        }
+
+        List<Boolean> results = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .thenApply(v -> futures.stream().map(CompletableFuture::join).toList())
+                .get();
+
+        long successCount = results.stream().filter(b -> b).count();
+        long failureCount = results.stream().filter(b -> !b).count();
+
+        Point actual = pointRepository.findByUserId(USER_ID).orElseThrow();
+        Quantity stockQuantity = productRepository.findById(1L).orElse(null).getStockQuantity();
+
+        assertSoftly(softly -> {
+            softly.assertThat(successCount)
+                    .as("결제 성공 건수")
+                    .isEqualTo(THREAD_COUNT);
+
+            softly.assertThat(actual.balance())
+                    .as("포인트 차감 후 잔액")
+                    .isEqualTo(beforeUserBalance.subtract(Money.of(totalPaymentAmount)));
+
+
+            softly.assertThat(stockQuantity.getAmount())
+                    .as("재고 차감 수량")
+                    .isEqualTo(1000 - 20);
+        });
+
+        log.info("✅ 결제 성공 수: " + successCount);
+        log.info("❌ 결제 실패 수: " + failureCount);
+        log.info("💰 남은 포인트: " + actual.balance().getAmount());
+        log.info("📦 남은 재고 수량: " + stockQuantity.getAmount());
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentUseCaseIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentUseCaseIntegrationTest.java
@@ -41,6 +41,48 @@ class PaymentUseCaseIntegrationTest {
     private static final int PRICE = 500;
 
     /*@Nested
+    @Test
+@DisplayName("유효한 사용자와 주문 ID로 주문 조회 및 수량 확인이 성공한다")
+void getOrderAndPrepareCheckStock_success() {
+    // Arrange
+    Product product = Product.create(PRODUCT_ID, "상품", PRICE, STOCK_QTY);
+    productRepository.save(product);
+
+    Order order = orderService.create(USER_ID, "order-004");
+    order.addLine(OrderLine.create(PRODUCT_ID, ORDER_QTY, product.getPrice()));
+    order.calculatePaymentAmount(product.getPrice() * ORDER_QTY);
+
+    PaymentInfo.Pay payInfo = new PaymentInfo.Pay(order.getId(), "CARD");
+
+    // Act
+    Order retrievedOrder = orderService.getUserOrder(USER_ID, payInfo.orderId());
+    List<OrderLine> orderLines = retrievedOrder.getOrderLines();
+
+    List<ProductCommand.CheckStock> checkStocksCommand = orderLines.stream()
+            .map(orderLine -> ProductCommand.CheckStock.of(orderLine.getProductId(), orderLine.getQuantity()))
+            .collect(Collectors.toList());
+
+    // Assert
+    assertThat(orderLines).hasSize(1);
+    assertThat(checkStocksCommand).hasSize(1);
+    assertThat(checkStocksCommand.get(0).productId()).isEqualTo(PRODUCT_ID);
+    assertThat(checkStocksCommand.get(0).quantity().value()).isEqualTo(ORDER_QTY);
+}
+
+@Test
+@DisplayName("존재하지 않는 주문 ID로 주문 조회 시 예외가 발생한다")
+void getOrderAndPrepareCheckStock_fail_due_to_invalidOrder() {
+    // Arrange
+    Long invalidOrderId = 9999L; // 존재하지 않는 주문
+    PaymentInfo.Pay payInfo = new PaymentInfo.Pay(invalidOrderId, "CARD");
+
+    // Act & Assert
+    assertThatThrownBy(() -> orderService.getUserOrder(USER_ID, payInfo.orderId()))
+            .isInstanceOf(CoreException.class)
+            .hasMessageContaining("주문을 찾을 수 없습니다");
+}
+
+
     @DisplayName("결제 성공 시")
     class SuccessCase {
 

--- a/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentUseCaseIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/application/payment/PaymentUseCaseIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.loopers.application.payment;
 
+
 import com.loopers.domain.commonvo.Money;
 import com.loopers.domain.commonvo.Quantity;
 import com.loopers.domain.order.*;
@@ -47,6 +48,7 @@ class PaymentUseCaseIntegrationTest {
     private PointService pointService;
     @Autowired
     private PaymentService paymentService;
+
     @MockitoSpyBean
     private OrderRepository orderRepository;
     @MockitoSpyBean
@@ -55,53 +57,25 @@ class PaymentUseCaseIntegrationTest {
     private PointRepository pointRepository;
     @MockitoSpyBean
     private PaymentRepository paymentRepository;
+
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
 
-    private static OrderLineService orderLineService = new OrderLineService();
+    private static final OrderLineService orderLineService = new OrderLineService();
     private static final Long USER_ID = 1L;
     private static final String ORDER_REQUEST_ID = "order-123";
 
     private Long productId1;
     private Long productId2;
-    private Money userBalance;
     private Long orderId;
-    List<Product> products = new ArrayList<>();
+    private Money userBalance;
+    private final List<Product> products = new ArrayList<>();
+    private Point point;
 
     @BeforeEach
     void setUp() {
-        Long brandId = 1L;
-
-        Product product1 = Product.from("상품1", 1000L, ProductStatus.AVAILABLE, 0, Quantity.of(10)
-                , LocalDate.now().minusDays(1), brandId);
-        Product product2 = Product.from("상품2", 2000L, ProductStatus.AVAILABLE, 0, Quantity.of(10)
-                , LocalDate.now().minusDays(1), brandId);
-        products.add(product1);
-        products.add(product2);
-
-        productRepository.save(product1);
-        productRepository.save(product2);
-        productId1 = product1.getId();
-        productId2 = product2.getId();
-
-        Point point = pointRepository.save(Point.create(USER_ID, Money.of(10_000L)));
-        userBalance = point.balance();
-    }
-
-    private void prepareOrderAndOrderLines(Quantity product1Quantity, Quantity product2Quantity) {
-        Order order = Order.create(USER_ID, ORDER_REQUEST_ID);
-        List<OrderLineCommand> orderLineCommands =
-                List.of(
-                        new OrderLineCommand(productId1, product1Quantity),
-                        new OrderLineCommand(productId2, product2Quantity)
-                );
-        List<OrderLine> orderLines = orderLineService.createOrderLines(orderLineCommands, products);
-        order.addOrderLine(orderLines);
-
-        order.calculateOrderAmount();
-        order.applyDiscount(Money.ZERO);
-        orderRepository.save(order);
-        orderId = order.getId();
+        setupProducts();
+        setupUserPoint();
     }
 
     @AfterEach
@@ -109,138 +83,150 @@ class PaymentUseCaseIntegrationTest {
         databaseCleanUp.truncateAllTables();
     }
 
+    private void setupProducts() {
+        Long brandId = 1L;
+        Product product1 = Product.from("상품1", 1000L, ProductStatus.AVAILABLE, 0, Quantity.of(10), LocalDate.now().minusDays(1), brandId);
+        Product product2 = Product.from("상품2", 2000L, ProductStatus.AVAILABLE, 0, Quantity.of(10), LocalDate.now().minusDays(1), brandId);
+
+        productRepository.save(product1);
+        productRepository.save(product2);
+
+        productId1 = product1.getId();
+        productId2 = product2.getId();
+
+        products.add(product1);
+        products.add(product2);
+    }
+
+    private void setupUserPoint() {
+        //todo: 밑에 달아둔 주석이 영속성 컨텍스트에 의해 이후 값이 변경될 수 있다는 것이 아닐 수 있는 것 같다. 실패해서 검증 시 새로 조회했다.
+        point = pointRepository.save(Point.create(USER_ID, Money.of(10_000L))); //주의: 영속성 컨텍스트에 의해 이후 값이 변경될 수 있음
+        userBalance = point.balance(); // 주의: 조회 시점의 스냅샷 값. 이후 balance 변경 시 반영되지 않음
+    }
+
+    private void prepareOrderAndOrderLines(Quantity q1, Quantity q2) {
+        Order order = Order.create(USER_ID, ORDER_REQUEST_ID);
+        List<OrderLineCommand> commands = List.of(
+                new OrderLineCommand(productId1, q1),
+                new OrderLineCommand(productId2, q2)
+        );
+        List<OrderLine> orderLines = orderLineService.createOrderLines(commands, products);
+        order.addOrderLine(orderLines);
+        order.calculateOrderAmount();
+        order.applyDiscount(Money.ZERO);
+        orderRepository.save(order);
+        orderId = order.getId();
+    }
+
     @Test
     @DisplayName("결제 성공 시, 결제 성공 이력이 저장된다")
     void pay_success() {
-        Quantity product1Quantity = Quantity.of(2);
-        Quantity product2Quantity = Quantity.of(2);
-        prepareOrderAndOrderLines(product1Quantity, product2Quantity);
+        prepareOrderAndOrderLines(Quantity.of(2), Quantity.of(2));
 
         PaymentInfo.Pay payInfo = new PaymentInfo.Pay(orderId, PaymentMethod.POINT);
         Order order = orderRepository.findByIdWithOrderLines(orderId).orElseThrow();
-        Money expectedPaymentAmount = order.getPaymentAmount();
+        Money expectedAmount = order.getPaymentAmount();
 
-        // act
         PaymentResult.Pay result = sut.pay(USER_ID, payInfo);
-
-        // assert
-        assertThat(result.paymentId()).isNotNull();
-
         Payment payment = paymentRepository.findById(result.paymentId()).orElseThrow();
+
         assertAll(
+                () -> assertThat(result.paymentId()).isNotNull(),
                 () -> assertThat(payment.getFailureReason()).isNull(),
                 () -> assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.CONFIRMED),
-                () -> assertThat(payment.getAmount()).isEqualTo(expectedPaymentAmount)
+                () -> assertThat(payment.getAmount()).isEqualTo(expectedAmount)
         );
     }
 
     @Test
-    @DisplayName("하나의 상품이라도 재고 부족 시, 주문 상품들의 모든 재고가 차감이 되지 않고 결제 실패 이력이 저장되고 CONFLICT 예외가 발생한다.")
+    @DisplayName("하나라도 재고 부족 시, 전체 재고 차감 없이 주문/결제 실패 이력이 저장되고 CONFLICT 예외 발생")
     void pay_fail_due_to_stock() {
-        Quantity product1Quantity = Quantity.of(3);
-        Quantity product2Quantity = Quantity.of(20);
-        prepareOrderAndOrderLines(product1Quantity, product2Quantity);
+        prepareOrderAndOrderLines(Quantity.of(3), Quantity.of(20));
 
-        Product beforeProduct1 = productRepository.findById(productId1).orElseThrow();
-        Product beforeProduct2 = productRepository.findById(productId2).orElseThrow();
-        Quantity product1Stock = beforeProduct1.getStockQuantity();
-        Quantity product2Stock = beforeProduct2.getStockQuantity();
+        Product before1 = productRepository.findById(productId1).orElseThrow();
+        Product before2 = productRepository.findById(productId2).orElseThrow();
 
-        PaymentInfo.Pay payInfo = new PaymentInfo.Pay(orderId, PaymentMethod.POINT);
-
-        // act
-        CoreException exception = assertThrows(CoreException.class, ()
-                -> sut.pay(USER_ID, payInfo)
-        );
-
-        // assert
-        assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
-        assertThat(exception.getMessage()).contains(PaymentFailureReason.OUT_OF_STOCK.getMessage());
+        CoreException ex = assertThrows(CoreException.class,
+                () -> sut.pay(USER_ID, new PaymentInfo.Pay(orderId, PaymentMethod.POINT)));
 
         Payment payment = paymentRepository.findByOrderId(orderId).orElseThrow();
-        Product afterProduct1 = productRepository.findById(productId1).orElseThrow();
-        Product afterProduct2 = productRepository.findById(productId2).orElseThrow();
+        Product after1 = productRepository.findById(productId1).orElseThrow();
+        Product after2 = productRepository.findById(productId2).orElseThrow();
+
         assertAll(
-                () -> assertThat(afterProduct1.getStockQuantity().getAmount()).isEqualTo(product1Stock.getAmount()),
-                () -> assertThat(afterProduct2.getStockQuantity()).isEqualTo(product2Stock),
-                () -> assertThat(payment.getId()).isNotNull(),
+                () -> assertThat(ex.getErrorType()).isEqualTo(ErrorType.CONFLICT),
+                () -> assertThat(ex.getMessage()).contains(PaymentFailureReason.OUT_OF_STOCK.getMessage()),
+                () -> assertThat(after1.getStockQuantity()).isEqualTo(before1.getStockQuantity()),
+                () -> assertThat(after2.getStockQuantity()).isEqualTo(before2.getStockQuantity()),
                 () -> assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.CANCELED),
                 () -> assertThat(payment.getFailureReason()).isEqualTo(PaymentFailureReason.OUT_OF_STOCK)
         );
     }
 
     @Test
-    @DisplayName("모든 상품의 재고가 충분한 경우, 재고가 차감되고 결제 성공 이력이 저장된다.")
+    @DisplayName("재고 충분한 경우, 재고/포인트가 차감되고 주문/결제 성공 이력이 저장된다")
     void paySuccess_whenOrderLinesSufficientStock() {
-        // Arrange
-        Quantity product1Quantity = Quantity.of(2);
-        Quantity product2Quantity = Quantity.of(1);
-        prepareOrderAndOrderLines(product1Quantity, product2Quantity);
+        Quantity q1 = Quantity.of(2);
+        Quantity q2 = Quantity.of(1);
+        prepareOrderAndOrderLines(q1, q2);
 
-        // 충분한 재고 보장
-        Product beforeProduct1 = productRepository.findById(productId1).orElseThrow();
-        Product beforeProduct2 = productRepository.findById(productId2).orElseThrow();
-        Quantity product1StockBefore = beforeProduct1.getStockQuantity();
-        Quantity product2StockBefore = beforeProduct2.getStockQuantity();
+        Product before1 = productRepository.findById(productId1).orElseThrow();
+        Product before2 = productRepository.findById(productId2).orElseThrow();
+        Quantity before1Quantity = before1.getStockQuantity();
+        Quantity before2Quantity = before2.getStockQuantity();
 
-        PaymentInfo.Pay payInfo = new PaymentInfo.Pay(orderId, PaymentMethod.POINT);
+        Point beforePoint = pointRepository.findByUserId(USER_ID).orElseThrow();
+        Money userBalance = beforePoint.balance();
 
-        // Act
-        PaymentResult.Pay result = sut.pay(USER_ID, payInfo);
+        //act
+        PaymentResult.Pay result = sut.pay(USER_ID, new PaymentInfo.Pay(orderId, PaymentMethod.POINT));
 
-        // Assert
-        Product afterProduct1 = productRepository.findById(productId1).orElseThrow();
-        Product afterProduct2 = productRepository.findById(productId2).orElseThrow();
+        // assert
         Payment payment = paymentRepository.findById(result.paymentId()).orElseThrow();
+        Product after1 = productRepository.findById(productId1).orElseThrow();
+        Product after2 = productRepository.findById(productId2).orElseThrow();
+        Money expectedDeductedAmount = before1.getPrice().multiply(q1)
+                .add(before2.getPrice().multiply(q2));
+        Point afterPoint = pointRepository.findByUserId(USER_ID).orElseThrow();
 
         assertAll(
-                () -> assertThat(result.paymentId()).isNotNull(),
-                () -> assertThat(afterProduct1.getStockQuantity())
-                        .isEqualTo(product1StockBefore.subtract(product1Quantity)),
-                () -> assertThat(afterProduct2.getStockQuantity())
-                        .isEqualTo(product2StockBefore.subtract(product2Quantity)),
+                () -> assertThat(payment.getFailureReason()).isNull(),
                 () -> assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.CONFIRMED),
-                () -> assertThat(payment.getFailureReason()).isNull()
+                // 재고 확인
+                () -> assertThat(after1.getStockQuantity().getAmount()).isEqualTo(before1Quantity.subtract(Quantity.of(2)).getAmount()),
+                () -> assertThat(after2.getStockQuantity()).isEqualTo(before2Quantity.subtract(Quantity.of(1))),
+                // 포인트 차감 확인
+                () -> assertThat(afterPoint.balance().getAmount()).isEqualTo(userBalance.subtract(expectedDeductedAmount).getAmount())
         );
     }
 
-
     @Test
-    @DisplayName("포인트 부족 시, 재고, 포인트는 차감되지 않으며 결제 실패 이력이 저장되고 CONFLICT 예외가 발생한다")
+    @DisplayName("포인트 부족 시, 포인트와 재고는 차감되지 않고 결제 실패 이력이 저장되고 CONFLICT 예외 발생")
     void pay_fail_due_to_point() {
-        Quantity product1Quantity = Quantity.of(3);
-        Quantity product2Quantity = Quantity.of(10);
+        prepareOrderAndOrderLines(Quantity.of(3), Quantity.of(10)); // 금액 초과
         //경계값 테스트. 보유량 10개인데, 10개 사용.
         //todo: 에러코드를 남겨둬야 어디서 발생한 에러인지 금방 찾을 것 같다. 수량이 0이 되면 안되게 해놨었다. 현재는 마이너스만 안되게 수정함.
 
-        prepareOrderAndOrderLines(product1Quantity, product2Quantity);
-
-        // 주문 금액보다 보유 포인트가 작다.
         Order order = orderRepository.findByIdWithOrderLines(orderId).orElseThrow();
-        Money paymentAmount = order.getPaymentAmount();
-        assertThat(userBalance.isLessThan(paymentAmount)).isTrue();
+        assertThat(userBalance.isLessThan(order.getPaymentAmount())).isTrue();
 
-        PaymentInfo.Pay payInfo = new PaymentInfo.Pay(orderId, PaymentMethod.POINT);
-
-        // act
-        CoreException exception = assertThrows(CoreException.class, () -> sut.pay(USER_ID, payInfo));
-
-        // assert
-        assertThat(exception.getErrorType()).isEqualTo(ErrorType.CONFLICT);
-        assertThat(exception.getMessage()).contains(PaymentFailureReason.INSUFFICIENT_BALANCE.getMessage());
+        CoreException ex = assertThrows(CoreException.class,
+                () -> sut.pay(USER_ID, new PaymentInfo.Pay(orderId, PaymentMethod.POINT)));
 
         Payment payment = paymentRepository.findByOrderId(orderId).orElseThrow();
-        assertAll(
+        Product current1 = productRepository.findById(productId1).orElseThrow();
+        Product current2 = productRepository.findById(productId2).orElseThrow();
+        Point currentPoint = pointRepository.findByUserId(USER_ID).orElseThrow();
 
-                () -> assertThat(payment.getId()).isNotNull(),
+        assertAll(
+                () -> assertThat(ex.getErrorType()).isEqualTo(ErrorType.CONFLICT),
+                () -> assertThat(ex.getMessage()).contains(PaymentFailureReason.INSUFFICIENT_BALANCE.getMessage()),
                 () -> assertThat(payment.getPaymentStatus()).isEqualTo(PaymentStatus.CANCELED),
-                //유저의 포인트량이 동일한지 확인.
-                () -> assertThat(userBalance).isEqualTo(pointRepository.findByUserId(USER_ID).orElseThrow().balance()),
-                //재고가 동일한지 확인
-                () -> assertThat(productRepository.findById(productId1).orElseThrow().getStockQuantity().getAmount())
-                        .isEqualTo(products.get(0).getStockQuantity().getAmount()),
-                () -> assertThat(productRepository.findById(productId2).orElseThrow().getStockQuantity().getAmount())
-                        .isEqualTo(products.get(1).getStockQuantity().getAmount())
+                () -> assertThat(payment.getFailureReason()).isEqualTo(PaymentFailureReason.INSUFFICIENT_BALANCE),
+                () -> assertThat(currentPoint.balance()).isEqualTo(userBalance),
+                () -> assertThat(current1.getStockQuantity().getAmount()).isEqualTo(products.get(0).getStockQuantity().getAmount()),
+                () -> assertThat(current2.getStockQuantity()).isEqualTo(products.get(1).getStockQuantity())
         );
     }
 }
+

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderLineServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderLineServiceTest.java
@@ -1,0 +1,111 @@
+package com.loopers.domain.order;
+
+
+import com.loopers.domain.commonvo.Quantity;
+import com.loopers.domain.product.Product;
+import com.loopers.domain.product.ProductStatus;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.assertThrows;
+
+class OrderLineServiceTest {
+
+    private final OrderLineService sut = new OrderLineService();
+
+    private Product createProduct(Long id, long price) {
+        Product product = Product.from("상품", price, ProductStatus.AVAILABLE, 0, Quantity.of(10), LocalDate.now(), 1L);
+        // 테스트용으로 ID 세팅 (JPA 없이 단위 테스트라면 강제 가능)
+        ReflectionTestUtils.setField(product, "id", id);
+        return product;
+    }
+
+
+    @Test
+    @DisplayName("상품 목록에 없는 ID가 포함되면 예외가 발생한다")
+    void createOrderLines_fail_dueToMissingProduct() {
+        // given
+        Product product = createProduct(1L, 1000L);
+        List<Product> products = List.of(product);
+
+        List<OrderLineCommand> lines = List.of(
+                new OrderLineCommand(1L, Quantity.of(2)),
+                new OrderLineCommand(2L, Quantity.of(1)) // 2L는 없음
+        );
+
+        // when & then
+        CoreException exception = assertThrows(CoreException.class,
+                () -> sut.createOrderLines(lines, products));
+
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("상품 개수가 주문 라인보다 많으면 예외가 발생한다")
+    void createOrderLines_fail_dueToExtraProducts() {
+        // given
+        Product product1 = createProduct(1L, 1000L);
+        Product product2 = createProduct(2L, 2000L);
+        Product extra = createProduct(3L, 3000L);
+
+        List<Product> products = List.of(product1, product2, extra); // 3개
+        List<OrderLineCommand> lines = List.of(
+                new OrderLineCommand(1L, Quantity.of(1)),
+                new OrderLineCommand(2L, Quantity.of(1))
+        ); // 2개
+
+        // when & then
+        CoreException exception = assertThrows(CoreException.class,
+                () -> sut.createOrderLines(lines, products));
+
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        assertThat(exception.getMessage()).contains("일치하지 않습니다");
+    }
+
+    @Test
+    @DisplayName("상품 개수가 주문 라인보다 적으면 예외가 발생한다")
+    void createOrderLines_fail_dueToMissingProducts() {
+        // given
+        Product product = createProduct(1L, 1000L);
+        List<Product> products = List.of(product); // 1개
+
+        List<OrderLineCommand> lines = List.of(
+                new OrderLineCommand(1L, Quantity.of(1)),
+                new OrderLineCommand(2L, Quantity.of(1)) // 2L는 없음
+        ); // 2개
+
+        // when & then
+        CoreException exception = assertThrows(CoreException.class,
+                () -> sut.createOrderLines(lines, products));
+
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("상품 ID가 모두 일치하고 개수도 같으면 OrderLine을 정상 생성한다")
+    void createOrderLines_success() {
+        // given
+        Product product1 = createProduct(1L, 1000L);
+        Product product2 = createProduct(2L, 2000L);
+
+        List<Product> products = List.of(product1, product2);
+        List<OrderLineCommand> lines = List.of(
+                new OrderLineCommand(1L, Quantity.of(2)),
+                new OrderLineCommand(2L, Quantity.of(1))
+        );
+
+        // when
+        List<OrderLine> orderLines = sut.createOrderLines(lines, products);
+
+        // then
+        assertThat(orderLines).hasSize(2);
+        assertThat(orderLines).extracting(OrderLine::getProductId).containsExactly(1L, 2L);
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderServiceIntegrationTest.java
@@ -130,7 +130,7 @@ class OrderServiceIntegrationTest {
 
             // Act
             boolean isPaymentConfirmed = true;
-            sut.finalizePaymentResult(order, isPaymentConfirmed);
+            sut.finalizeOrderResult(order, isPaymentConfirmed);
 
             // Assert
             assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID);
@@ -144,7 +144,7 @@ class OrderServiceIntegrationTest {
 
             // Act
             boolean isPaymentConfirmed = false;
-            sut.finalizePaymentResult(order, isPaymentConfirmed);
+            sut.finalizeOrderResult(order, isPaymentConfirmed);
 
             // Assert
             assertThat(order.getStatus()).isEqualTo(OrderStatus.PAID_FAILED);

--- a/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentServiceIntegrationTest.java
@@ -1,0 +1,81 @@
+package com.loopers.domain.payment;
+
+import com.loopers.domain.commonvo.Money;
+import com.loopers.infrastructure.payment.PaymentJpaRepository;
+import com.loopers.testcontainers.MySqlTestContainersConfig;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Import(MySqlTestContainersConfig.class)
+public class PaymentServiceIntegrationTest {
+
+    @Autowired
+    private PaymentService sut;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @MockitoSpyBean
+    private PaymentJpaRepository paymentRepository;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("결제 저장 시,")
+    @Nested
+    class Save {
+
+        private final Long orderId = 1L;
+        private final Money amount = Money.of(1000L);
+
+        @Test
+        @DisplayName("정상 결제일 경우, CONFIRMED 상태로 저장된다.")
+        void saveConfirmedPayment() {
+            // Act
+            boolean isPaymentConfirmed = true;
+            Long paymentId = sut.save(orderId, PaymentMethod.POINT, amount, isPaymentConfirmed);
+
+            // Assert
+            Payment actual = paymentRepository.findById(paymentId).orElseThrow();
+            assertAll(
+                    () -> assertThat(actual.getOrderId()).isEqualTo(orderId),
+                    () -> assertThat(actual.getAmount()).isEqualTo(amount),
+                    () -> assertThat(actual.getPaymentMethod()).isEqualTo(PaymentMethod.POINT),
+                    () -> assertThat(actual.getPaymentStatus()).isEqualTo(PaymentStatus.CONFIRMED)
+            );
+
+            ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+            verify(paymentRepository, times(1)).save(paymentCaptor.capture());
+            assertThat(paymentCaptor.getValue().getOrderId()).isEqualTo(orderId);
+        }
+
+        @Test
+        @DisplayName("결제 실패일 경우, CANCELED 상태로 저장된다.")
+        void saveCanceledPayment() {
+            // Act
+            boolean isPaymentConfirmed = false;
+            Long paymentId = sut.save(orderId, PaymentMethod.POINT, amount, isPaymentConfirmed);
+
+            // Assert
+            Payment actual = paymentRepository.findById(paymentId).orElseThrow();
+            assertAll(
+                    () -> assertThat(actual.getOrderId()).isEqualTo(orderId),
+                    () -> assertThat(actual.getAmount()).isEqualTo(amount),
+                    () -> assertThat(actual.getPaymentStatus()).isEqualTo(PaymentStatus.CANCELED)
+            );
+            verify(paymentRepository, times(1)).save(any(Payment.class));
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/payment/PaymentTest.java
@@ -2,7 +2,6 @@ package com.loopers.domain.payment;
 
 import com.loopers.domain.commonvo.Money;
 import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,7 +26,7 @@ class PaymentTest {
         @DisplayName("결제 정보를 전달하면, Payment 객체가 정상적으로 생성된다.")
         void createPayment_successfully() {
             // Act
-            Payment payment = Payment.confirm(ORDER_ID, PAYMENT_METHOD, AMOUNT, PaymentStatus.CONFIRMED);
+            Payment payment = Payment.confirmSuccess(ORDER_ID, PAYMENT_METHOD, AMOUNT, PaymentStatus.CONFIRMED);
 
             // Assert
             assertAll(
@@ -63,13 +62,13 @@ class PaymentTest {
                     () -> {
                         Long nullOrderId = null;
                         assertThrows(CoreException.class, () ->
-                                Payment.confirm(nullOrderId, validMethod, validAmount, validStatus)
+                                Payment.confirmSuccess(nullOrderId, validMethod, validAmount, validStatus)
                         );
                     },
                     () -> {
                         PaymentMethod nullPaymentMethod = null;
                         assertThrows(CoreException.class, () ->
-                                Payment.confirm(validOrderId, nullPaymentMethod, validAmount, validStatus)
+                                Payment.confirmSuccess(validOrderId, nullPaymentMethod, validAmount, validStatus)
                         );
                     },
 //                    () -> {
@@ -81,7 +80,7 @@ class PaymentTest {
                     () -> {
                         PaymentStatus nullPaymentStatus = null;
                         assertThrows(CoreException.class, () ->
-                                Payment.confirm(validOrderId, validMethod, validAmount, nullPaymentStatus)
+                                Payment.confirmSuccess(validOrderId, validMethod, validAmount, nullPaymentStatus)
                         );
                     }
             );

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -125,10 +125,11 @@ public class PointServiceIntegrationTest {
     class Use {
         private final Long userId = 1L;
         private final Money initialAmount = Money.of(1000L);
+        private Point point;
 
         @BeforeEach
         void setUp() {
-            Point point = Point.create(userId, initialAmount);
+            point = Point.create(userId, initialAmount);
             pointRepository.save(point);
         }
 
@@ -139,7 +140,7 @@ public class PointServiceIntegrationTest {
             Money useAmount = Money.of(300L);
 
             // Act
-            sut.use(userId, useAmount);
+            sut.useOrThrow(point, useAmount);
 
             // Assert
             Point actual = pointRepository.findByUserId(userId).orElseThrow();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -325,6 +325,10 @@ class ProductServiceIntegrationTest {
             // Act
             sut.decreaseLikeCount(product);
 
+            // 영속성 컨텍스트 동기화 및 캐시 초기화
+            em.flush();
+            em.clear();
+
             // Assert
             Product actual = productRepository.findById(product.getId()).orElseThrow();
             assertThat(actual.getLikeCount().getValue()).isEqualTo(beforeLikeCount - 1);

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -22,7 +22,6 @@ import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
@@ -298,7 +297,7 @@ class ProductServiceIntegrationTest {
                     .getLikeCount().getValue();
 
             // Act
-            sut.increaseLikeCount(product);
+            sut.increaseLikeCountOld(product);
 
             // Assert
             Product actual = productRepository.findById(product.getId()).orElseThrow();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -9,6 +9,8 @@ import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.testcontainers.MySqlTestContainersConfig;
 import com.loopers.utils.DatabaseCleanUp;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +43,9 @@ class ProductServiceIntegrationTest {
 
     @MockitoSpyBean
     private BrandRepository brandRepository;
+
+    @PersistenceContext
+    private EntityManager em;
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
@@ -297,7 +302,11 @@ class ProductServiceIntegrationTest {
                     .getLikeCount().getValue();
 
             // Act
-            sut.increaseLikeCount(product);
+            sut.increaseLikeCountAtomically(product); //jpql update 쿼리 호출
+
+            // 영속성 컨텍스트 동기화 및 캐시 초기화
+            em.flush();
+            em.clear();
 
             // Assert
             Product actual = productRepository.findById(product.getId()).orElseThrow();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -290,6 +290,7 @@ class ProductServiceIntegrationTest {
 
         @Test
         @DisplayName("increaseLikeCount를 호출하면, 좋아요 수가 1 증가분이 DB에 반영된다.")
+        @Transactional
         void increaseLikeCount() {
             // arrange
             int beforeLikeCount = productRepository.findById(product.getId())
@@ -306,6 +307,7 @@ class ProductServiceIntegrationTest {
 
         @Test
         @DisplayName("decreaseLikeCount를 호출하면, 좋아요 수가 1 감소분이 DB에 반영된다.")
+        @Transactional // todo: 트랜잭션이 없으면, JPA가 영속성 컨텍스트를 플러시하지 않아 변경 사항이 DB에 반영되지 않음. 이 테스트가 과연 필요할까? 이런 테스트는  usecase 단위로 통합테스트코드 작성하는 것이 맞다고 생각함.
         void decreaseLikeCount() {
             // Arrange
             product.increaseLikeCount(); // 먼저 증가

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -297,7 +297,7 @@ class ProductServiceIntegrationTest {
                     .getLikeCount().getValue();
 
             // Act
-            sut.increaseLikeCountOld(product);
+            sut.increaseLikeCount(product);
 
             // Assert
             Product actual = productRepository.findById(product.getId()).orElseThrow();

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -232,6 +232,7 @@ class ProductServiceIntegrationTest {
 
         @Test
         @DisplayName("모든 상품 ID가 유효하면, 상품 리스트를 반환한다.")
+        @Transactional //비관적락은 트랜잭션이 있어야 동작한다.
         void findAllValidProductsOrThrow_success() {
             // Arrange
             List<Long> validIds = productRepository.findAll().stream()
@@ -249,6 +250,7 @@ class ProductServiceIntegrationTest {
 
         @Test
         @DisplayName("상품 ID 중 하나라도 존재하지 않으면, NOT_FOUND  예외가 발생한다.")
+        @Transactional //비관적락은 트랜잭션이 있어야 동작한다.
         void findAllValidProductsOrThrow_fail_whenAnyMissing() {
             // Arrange
             List<Long> validProductIds = productRepository.findAll().stream()

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -236,7 +236,7 @@ class ProductServiceIntegrationTest {
                     .toList();
 
             // Act
-            List<Product> products = sut.findAllValidProductsOrThrow(Set.copyOf(validIds));
+            List<Product> products = sut.findAllValidProductsOrThrow(validIds);
 
             // Assert
             assertThat(products).hasSize(validIds.size());
@@ -252,7 +252,7 @@ class ProductServiceIntegrationTest {
                     .limit(2)
                     .toList();
             Long invalidProductId = -999L;
-            Set<Long> mixedIds = Set.of(validProductIds.get(0), validProductIds.get(1), invalidProductId);
+            List<Long> mixedIds = List.of(validProductIds.get(0), validProductIds.get(1), invalidProductId);
 
             // Act
             CoreException exception = assertThrows(CoreException.class,
@@ -376,9 +376,9 @@ class ProductServiceIntegrationTest {
             Quantity deductQuantity1 = Quantity.of(5);
             Quantity deductQuantity2 = Quantity.of(3);
 
-            List<ProductCommand.CheckStock> commands = List.of(
-                    new ProductCommand.CheckStock(product1.getId(), deductQuantity1),
-                    new ProductCommand.CheckStock(product2.getId(), deductQuantity2)
+            List<ProductCommand.DeductStock> commands = List.of(
+                    new ProductCommand.DeductStock(product1, deductQuantity1),
+                    new ProductCommand.DeductStock(product2, deductQuantity2)
             );
 
             Quantity beforeStockOfProduct1 = product1.getStockQuantity();
@@ -398,8 +398,6 @@ class ProductServiceIntegrationTest {
                     () -> assertThat(actualProduct2.getStockQuantity()).isEqualTo(beforeStockOfProduct2.subtract(deductQuantity2)),
                     () -> assertThat(actualProduct2.getStatus()).isEqualTo(ProductStatus.AVAILABLE)
             );
-
-            verify(productRepository, times(1)).findAllByIds(List.of(product1.getId(), product2.getId()));
         }
 
         @Test
@@ -407,8 +405,8 @@ class ProductServiceIntegrationTest {
         void markSoldOutAndThrowException_whenStockNotEnough() {
             // Arrange
             Quantity overQuantity = Quantity.of(200); // 현재 재고보다 많은 수량
-            List<ProductCommand.CheckStock> commands = List.of(
-                    new ProductCommand.CheckStock(product1.getId(), overQuantity)
+            List<ProductCommand.DeductStock> commands = List.of(
+                    new ProductCommand.DeductStock(product1, overQuantity)
             );
             Quantity beforeStockOfProduct1 = product1.getStockQuantity();
 
@@ -422,9 +420,6 @@ class ProductServiceIntegrationTest {
                     () -> assertThat(isDeductStock).isFalse(),
                     () -> assertThat(updated.getStatus()).isEqualTo(ProductStatus.OUT_OF_STOCK)
             );
-
-            verify(productRepository, times(1)).findAllByIds(List.of(product1.getId()));
         }
-
     }
 }

--- a/apps/commerce-api/src/test/resources/sql/coupon-concurrent-data.sql
+++ b/apps/commerce-api/src/test/resources/sql/coupon-concurrent-data.sql
@@ -1,0 +1,16 @@
+-- 브랜드 및 상품
+INSERT INTO brand (id, name, description, status) VALUES (1, '나이키', '글로벌 브랜드', 'ACTIVE');
+ INSERT INTO product (name, price, like_count, stock_quantity, brand_id, status, created_at, sale_start_date)
+ VALUES ('테스트상품', 1000, 0, 1000, 1, 'AVAILABLE', NOW(), NOW());
+
+
+-- 포인트
+INSERT INTO point (id, user_id, balance) VALUES (1, 1, 10000);
+
+-- 쿠폰
+INSERT INTO coupon (id, name, discount_type, discount_value, start_at, end_at)
+VALUES (1, '동시성 쿠폰', 'RATE', 0.100, '2025-01-01', '2099-01-01');
+
+-- 유저 쿠폰 (단 1개)
+INSERT INTO user_coupon (id, user_id, coupon_id, used, version, issued_at)
+VALUES (1, 1, 1, false, 0, now());

--- a/apps/commerce-api/src/test/resources/sql/order-concurrent-data.sql
+++ b/apps/commerce-api/src/test/resources/sql/order-concurrent-data.sql
@@ -1,0 +1,57 @@
+
+ -- 1. 유저 포인트 초기화
+ INSERT INTO point (user_id, balance) VALUES (1, 100000);
+
+ -- 2. 상품 1개 생성 (재고는 충분히 설정)
+ INSERT INTO product (name, price, like_count, stock_quantity, brand_id, status, created_at, sale_start_date)
+ VALUES ('테스트상품', 1000, 0, 1000, 1, 'AVAILABLE', NOW(), NOW());
+
+ -- 1. 주문 20건 INSERT
+ INSERT INTO orders
+     (id, user_id, status, total_amount, discount_amount, payment_amount, order_request_id, created_at)
+ VALUES
+     (1001, 1, 'PENDING', 1000, 0, 1000, 'req-1001', NOW()),
+     (1002, 1, 'PENDING', 1000, 0, 1000, 'req-1002', NOW()),
+     (1003, 1, 'PENDING', 1000, 0, 1000, 'req-1003', NOW()),
+     (1004, 1, 'PENDING', 1000, 0, 1000, 'req-1004', NOW()),
+     (1005, 1, 'PENDING', 1000, 0, 1000, 'req-1005', NOW()),
+     (1006, 1, 'PENDING', 1000, 0, 1000, 'req-1006', NOW()),
+     (1007, 1, 'PENDING', 1000, 0, 1000, 'req-1007', NOW()),
+     (1008, 1, 'PENDING', 1000, 0, 1000, 'req-1008', NOW()),
+     (1009, 1, 'PENDING', 1000, 0, 1000, 'req-1009', NOW()),
+     (1010, 1, 'PENDING', 1000, 0, 1000, 'req-1010', NOW()),
+     (1011, 1, 'PENDING', 1000, 0, 1000, 'req-1011', NOW()),
+     (1012, 1, 'PENDING', 1000, 0, 1000, 'req-1012', NOW()),
+     (1013, 1, 'PENDING', 1000, 0, 1000, 'req-1013', NOW()),
+     (1014, 1, 'PENDING', 1000, 0, 1000, 'req-1014', NOW()),
+     (1015, 1, 'PENDING', 1000, 0, 1000, 'req-1015', NOW()),
+     (1016, 1, 'PENDING', 1000, 0, 1000, 'req-1016', NOW()),
+     (1017, 1, 'PENDING', 1000, 0, 1000, 'req-1017', NOW()),
+     (1018, 1, 'PENDING', 1000, 0, 1000, 'req-1018', NOW()),
+     (1019, 1, 'PENDING', 1000, 0, 1000, 'req-1019', NOW()),
+     (1020, 1, 'PENDING', 1000, 0, 1000, 'req-1020', NOW());
+
+ -- 2. 주문 상품 1개씩 INSERT (상품 id = 1 사용, 수량 = 1, 가격 = 1000)
+ INSERT INTO order_line
+     (id, order_id, product_id, quantity_amount, product_price, created_at)
+ VALUES
+     (2001, 1001, 1, 1, 1000, NOW()),
+     (2002, 1002, 1, 1, 1000, NOW()),
+     (2003, 1003, 1, 1, 1000, NOW()),
+     (2004, 1004, 1, 1, 1000, NOW()),
+     (2005, 1005, 1, 1, 1000, NOW()),
+     (2006, 1006, 1, 1, 1000, NOW()),
+     (2007, 1007, 1, 1, 1000, NOW()),
+     (2008, 1008, 1, 1, 1000, NOW()),
+     (2009, 1009, 1, 1, 1000, NOW()),
+     (2010, 1010, 1, 1, 1000, NOW()),
+     (2011, 1011, 1, 1, 1000, NOW()),
+     (2012, 1012, 1, 1, 1000, NOW()),
+     (2013, 1013, 1, 1, 1000, NOW()),
+     (2014, 1014, 1, 1, 1000, NOW()),
+     (2015, 1015, 1, 1, 1000, NOW()),
+     (2016, 1016, 1, 1, 1000, NOW()),
+     (2017, 1017, 1, 1, 1000, NOW()),
+     (2018, 1018, 1, 1, 1000, NOW()),
+     (2019, 1019, 1, 1, 1000, NOW()),
+     (2020, 1020, 1, 1, 1000, NOW());

--- a/docs/design/03-class-diagrams.md
+++ b/docs/design/03-class-diagrams.md
@@ -370,3 +370,47 @@ class Money {
 }
 
 ```
+
+---
+
+# 쿠폰 
+
+```mermaid
+classDiagram
+    class Coupon {
+        - Long id
+        - String name
+        - LocalDate startAt
+        - LocalDate endAt
+        - DiscountPolicy discountPolicy
+        + validateUsable()
+    }
+
+    class DiscountPolicy {
+        - DiscountType discountType
+        - BigDecimal discountValue
+        + calculateDiscountAmount(Long totalPrice)
+    }
+
+    class DiscountType {
+        <<enum>>
+        RATE
+        FIXED_AMOUNT
+        + calculateDiscountAmount(Long totalPrice, BigDecimal discountValue): Money
+    }
+
+    class Money {
+        - Long amount
+        + of(Long): Money
+        + add(Money): Money
+        + subtract(Money): Money
+        + multiply(Quantity): Money
+        + isLessThan(Money): boolean
+    }
+
+    Coupon --> DiscountPolicy : has
+    DiscountPolicy --> DiscountType : uses
+    DiscountType --> Money : returns
+
+
+```

--- a/docs/design/04-erd.md
+++ b/docs/design/04-erd.md
@@ -107,6 +107,37 @@ POINT {
 }
 
 %% =========================
+%% coupon
+%% =========================
+COUPON {
+    bigint id PK
+    varchar(100) name
+    date start_at
+    date end_at
+    varchar discount_type
+    decimal discount_rate
+}
+
+USER_COUPON {
+    bigint id PK
+    bigint user_id
+    bigint coupon_id FK
+    boolean used   
+    datetime issued_at
+    datetime updated_at
+}
+
+COUPON_USE_HISTORY {
+    bigint id PK
+    bigint user_coupon_id FK
+    bigint user_id
+    bigint order_id
+    datetime used_at
+    decimal discount_applied_amount
+}
+
+
+%% =========================
 %% 관계
 %% =========================
 BRAND ||--o{ PRODUCT : "has many"
@@ -117,5 +148,7 @@ PRODUCT ||--o{ ORDER_LINE : "referenced by"
 ORDER ||--o| PAYMENT : "paid by"
 USER ||--o{ ORDER : "places"
 USER ||--|| POINT : "owns"
+COUPON ||--o{ USER_COUPON : "has"
+USER_COUPON ||--o{ COUPON_USAGE_HISTORY : "records"
 
 ```

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -58,8 +58,10 @@ spring:
 datasource:
   mysql-jpa:
     main:
-      maximum-pool-size: 10
+      maximum-pool-size: 25
       minimum-idle: 5
+#      connection-timeout: 6000 # 커넥션 획득 대기시간(ms) ( default: 6000 = 6sec )
+
 
 ---
 spring.config.activate.on-profile: dev


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->

## 💬 Review Points

### (1) 트랜잭션 처리  [결제요청usecase](https://github.com/mybloom/commerce-api/blob/round4_2/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentUseCase.java) , [결제실패처리](https://github.com/mybloom/commerce-api/blob/round4_2/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFailureHandler.java), [주문요청 usecase](https://github.com/mybloom/commerce-api/blob/round4_2/apps/commerce-api/src/main/java/com/loopers/application/order/OrderUseCase.java)
| 트랜잭션 처리 현황
주문과 결제가 **다른 API로 분리**된 구조입니다.
1. **성공/실패에 따라 저장해야 하는 도메인이 달라지는 경우 → 트랜잭션 분리 적용(**`REQUIRES_NEW 사용)`
    - "결제" 성공 처리 구간
        - “재고 차감, 포인트 차감, 쿠폰 원복, 결제 성공 처리” 가 같은 주기로 이뤄져 있어 하나의 트랜잭션으로 묶음.
    - 결제 실패 처리 구간
        - 결제 실패 처리, 주문 실패 처리
2. **성공/실패 관계없이 저장하는 도메인이 같은 경우** → 트랜잭션 분리하지 않고, rollback되지 않게 설정
    - "주문" 성공 처리 구간
        - 주문 생성, 주문 상태 변경
    - 주문 실패 처리 구간
        - 주문 생성, 주문 상태  변경

|❓멘토님께 여쭙고 싶은 점
- 결제라는 도메인 특성상 전체 과정이 하나의 결제 주기로 보장되어야 한다고 판단했습니다.
- 다만, 이 과정이 하나의 트랜잭션으로 묶이면서 길어질 수 있다는 우려가 있습니다.    
    → 이 부분에 대해 실무적으로 더 나은 구조가 있을지 피드백 부탁드립니다.

### (2) 주문 UseCase 내 ID 기반 유효성 검증 관련  [주문요청 usecase](https://github.com/mybloom/commerce-api/blob/round4_2/apps/commerce-api/src/main/java/com/loopers/application/order/OrderUseCase.java)
주문 요청 시, 사용자로부터 전달받는 값은 주로 productId, couponId 등 ID 목록입니다.
실제 처리를 위해서는 이 ID들을 기반으로 도메인 객체를 조회하고, 존재 여부나 비즈니스 조건에 대한 유효성 검증을 수행해야 합니다.
이 과정에서 다음과 같은 복잡함을 느꼈습니다:

- UseCase의 역할이 과도한 것 같다는 느낌
현재는 UseCase 내부에서 ID → 도메인 조회 → 유효성 검증까지 모두 수행하고 있는데,
이 책임을 도메인이나 별도의 컴포넌트로 분리하는 방식이 더 나은 설계일지 고민이 됩니다.
실무에서는 이와 같은 흐름을 어떻게 분리하거나 구조화하는지 궁금합니다.
- 코드 스타일에 대한 고민
List<Long>으로 받은 ID를 반복문으로 도메인 객체로 매핑하고 조건 검사를 수행하는 로직이 길고 복잡해집니다.
Map<Long, 도메인>을 만들어서 매핑을 도와주는 방식도 사용하는데요, 여전히 깔끔하지 않다고 느낍니다.
이러한 패턴을 더 깔끔하고 명확하게 표현할 수 있는 방법이나 스타일이 있다면 피드백 부탁드립니다.


### (3) 쿠폰 구현 (Enum 기반 할인 정책). [쿠폰관련도메인](https://github.com/mybloom/commerce-api/tree/round4_2/apps/commerce-api/src/main/java/com/loopers/domain/coupon)
- Enum에 추상 메서드를 정의하고 각 할인 정책을 enum 내부 메서드에 구현했습니다.  원래는 인터페이스 + 구현 클래스로 분리하고 싶었으나 
시간 제약상 단순하게 처리한 면이 있습니다.
확장성과 테스트 측면에서 좋은  실무에서 자주 쓰는 패턴이 있다면 추천 부탁드립니다. 
- Coupon, UserCoupon의 관계
  - UserCoupon은 쿠폰의 스냅샷 정보를 포함한다고 말씀해주셨는데요, 시간 상 UserCoupon을 사용할 때 주요 정보를 Coupon에서 가져오도록 만들었습니다. 
  - UserCoupon이 스냅샷이라면 Coupon과 함께 사용하지 않고 단독으로 사용해도 무방한지 여쭤보고 싶습니다. 
  - 여기서 db 관점과 도메인 관점이 혼동이 오기도 하는데요. 스냅샷이라면 UserCoupon은 db에서는 마치 비정규화된 테이블 형태이고, 도메인 엔티티는 그러지 않고 쿠폰과 유저쿠폰이 마치 잘 정규화된 형태로 나열해서 사용한다. 라고 봐도 될까요? 


### (4) JPA 사용 관련
JPA의 Lazy 로딩, 연관관계, 트랜잭션 범위 등 개념이 서로 얽히면서 혼란스러웠습니다.
예를 들어: Lazy로 설정했지만 join fetch로 가져오면 연관관계 매핑은 무의미해지는 건지? 같은 궁금증이 많았습니다.
이런 부분은 어떤 방식으로 공부하거나 연습을 하면 좋을지 조언을 듣고 싶습니다.

## ✅ Checklist
- [x] 쿠폰 도메인 개발 완료 : 사용자가 소유, 한번만 사용, 정액/정률 구분, 각 적용 로직 구현
- [x] 주문 : 전체 흐름 원자성 보장, 재고 문제 실패, 포인트 보유 문제 실패, 성공 정상 반영
- [x] 동시성 테스트 
   - [x] 좋아요 수 증감 : atomicUpdate
   - [x] 쿠폰 한번만 사용 : 낙관적락, 재시도 로직 없음
   - [x] 포인트 정상 차감 : 비관적락
   - [x] 재고 정상 차감: 비관적락
- [ ] 남은 부분
   - API interface 구현
   
---

🎯 Implementation Quest: Pass
💬 ReviewPoints

• 리뷰 포인트 1: 저는 명확하게 하나의 트랜잭션으로 묶여 있는 것에 대한 장점이 "결제" 라는 도메인 특성과 연관지었을 때 효과적이라고 생각합니다. 실무에서의 체크리스트에서는 보통 "짧은 DB 트랜잭션" 여러개, 상태 전이 등을 잘 구성해 Lock 에 대한 성능 저하를 고려하라고들 하지만, 이는 명확하게 "보상 트랜잭션" 개념이나 Fallback 등을 잘 구성할 수 있는 구조일 때 얘기이고, 이에 따른 코드 복잡도가 높아지면 저는 Trade-off 관점에서 너무 많은 것을 잃는 것이 아닐까? 라는 생각을 하는 편이예요. 현재와 같이 이벤트 기반이나 외부 PG API 요청 기반의 구현 등으로 이루어지지 않은 상황에서는 같은 DB에 대해 트랜잭션을 쪼갤 경우, 커넥션 을 계속 맺는다던지 하는 부가적인 오버헤드가 더 커질 수도 있기 때문에 결제 성공에 따른 확정 트랜잭션은 하나의 트랜잭션으로 원자적 처리로 간단하게 구현하는 것이 더 효과적일 것 같아요.
• 리뷰 포인트 2: 코드 레벨에서의 실무적 고민을 덧대어 보면 그 사이에 얇은 컴포넌트나 도메인 서비스를 두는 것도 방법일 것 같아요. 예를 들면, 현재 Usecase 에서 접근하고 있는 각 Service 에서 조회에 대한 검증까지 책임을 가진다던지 하는 것이죠. 혹은, application 계층에 Usecase 에서만 사용하는 별도의 Resolver 객체와 같은 ApplicationService 를 두어 Usecase 자체는 좀 더 얇은 구성, 각 애플리케이션 서비스는 기본 도메인 서비스보다 좀 더 풍부한 기능 제공을 결로 두는 것도 방법일 것 같네요. (현재는 조회 및 검증을 전부 Usecase 에서 하고 있으므로)
• 리뷰 포인트 3: enum 도 충분하지만 정책들이 변경되거나 할 때마다 해당 enum 자체를 수정해야하기 때문에 확장성이 용이하진 않을 수 있습니다.
UserCoupon 이 스냅샷 정보를 담게 된다면, 이미 발급 이후의 쿠폰이므로 단독 사용도 가능합니다. 부가적인 검증의 의미로 실제 이런 Coupon 이 있어? 를 검증해야할 수 있는데 이런 것들을 연관관계 등으로 표현하면 딱 좋은 구조가 될 것 같아요. 즉, 할인에 대한 계산 자체는 UserCoupon 단독으로 가능해야하고 필요하다면 관리/통계/운영 측면에서 참조가 필요할 경우, Coupon 을 접근하는 것이죠. DB 관점에서는 "비정규화" 지만, 도메인 관점에서는 발급과 동시에 "권리를 동봉" 하는 관점으로 보는 모델링이기 때문에 적절한 접근일 것 같아요.
• 리뷰 포인트 4: 각 기능에 대한 멘탈모델 경계를 잘 정하고, 접근해보면 좋아요.
연관관계 매핑 = 엔티티 그래프를 연결하는 행위 (방향, 키, 소유자) 이므로 라이프사이클이나 참조관계를 설명함
Fetch 전략 = 언제 SQL 날릴지. (기본은 Lazy 로 두고 필요할 때만 로딩) -> 여기서 join fetch 는 "특정 쿼리에서만" 함께 조회하겠다고 하는 것이기 때문에 어떤 접근의 유즈케이스로 볼 수 있음.
트랜잭션 범위 = DB 에서 잠금 등의 특성 뿐 아니라 영속성 컨텍스트 생명주기와 동일선상으로 접근.
✍️ Technical Writing Quest: Pass
→ rollback-only 마킹과 관련된 스프링 플랫폼 트랜잭션 전략에 대해 문제를 열심히 잘 접근한 것 같아요. 즉, 플랫폼 트랜잭션 레벨에서 마킹이 이미 되었기 때문에 뒤에도 마킹은 풀리지 않는다. 혹은 noRollbackFor 을 활용해 특정 에러에 대해서 스킵 처리를 할 수도 있는데, 이는 권장되진 않습니다. ( 진짜 실패했는데 커밋되어버릴 수도 있음 ) 실제 문제를 분석하기 위해서는 예외 catch 시점에 TransactionAspectSupport.currentTransactionStatus().isRollbackOnly() 로 확인하거나 트랜잭션 훅을 등록해 관측해볼 수도 있습니다. 아니면 오히려 명시적으로 예외 기반 소통을 하도록 하고 (catch 시점에 내가 정의한 예외 발생시키기) 이후 RestControllerAdvice 와 같은 글로벌 예외 핸들러에서 알아서 처리하게끔 하는 것도 방법이구요.. (return 이 아닌)