### PR TITLE
[Round7] ApplicationEvent 를 활용해 유스케이스의 후속 흐름 분리 및 비동기 트랜잭션 흐름 설계

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFailureHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/payment/PaymentFailureHandler.java
@@ -3,8 +3,11 @@ package com.loopers.application.payment;
 import com.loopers.application.payment.dto.PaymentFailureInfo;
 import com.loopers.domain.coupon.CouponService;
 import com.loopers.domain.order.OrderService;
+import com.loopers.domain.payment.Payment;
 import com.loopers.domain.payment.PaymentService;
+import com.loopers.domain.sharedkernel.PaymentEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +19,7 @@ public class PaymentFailureHandler {
     private final PaymentService paymentService;
     private final OrderService orderService;
     private final CouponService couponService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleFailedPointPayment(PaymentFailureInfo.Fail info) {
@@ -23,10 +27,11 @@ public class PaymentFailureHandler {
         couponService.restoreByUser(info.orderId(), info.userId());
 
         //결제 실패 저장 : 포인트의 경우 pending 상태 없이 실패 상태로 저장
-        paymentService.createFailedPayment(info.convertToCommand());
+        Payment payment = paymentService.createFailedPayment(info.convertToCommand());
 
-        //주문 실패 처리
-        orderService.markFailed(info.orderId());
+        //주문 실패 처리(이벤트)
+        PaymentEvent.PaymentFailed event = new PaymentEvent.PaymentFailed(payment.getId(), info.orderId());
+        eventPublisher.publishEvent(event);
     }
 
     @Transactional
@@ -35,10 +40,11 @@ public class PaymentFailureHandler {
         couponService.restore(info.orderId());
 
         //결제 실패 처리
-        paymentService.failViaCallback(info.orderId(), info.transactionKey(), info.failureReason());
+        Payment payment = paymentService.failViaCallback(info.orderId(), info.transactionKey(), info.failureReason());
 
-        //주문 실패 처리
-        orderService.markFailed(info.orderId());
+        //결제 실패 처리(이벤트)
+        PaymentEvent.PaymentFailed event = new PaymentEvent.PaymentFailed(payment.getId(), info.orderId());
+        eventPublisher.publishEvent(event);
     }
 
     @Transactional
@@ -49,9 +55,10 @@ public class PaymentFailureHandler {
         couponService.restore(info.orderId());
 
         //결제 실패 저장 : 실패 상태로 처음 저장
-        paymentService.createFailedCardPayment(info.convertToCommand());
+        Payment payment = paymentService.createFailedCardPayment(info.convertToCommand());
 
-        //주문 실패 처리
-        orderService.markFailed(info.orderId());
+        //결제 실패 처리(이벤트)
+        PaymentEvent.PaymentFailed event = new PaymentEvent.PaymentFailed(payment.getId(), info.orderId());
+        eventPublisher.publishEvent(event);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponCommand.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponCommand.java
@@ -24,5 +24,13 @@ public final class CouponCommand {
                     .orderId(orderId)
                     .build();
         }
+
+        public static ApplyDiscount of(Long userId, List<Long> userCouponIds, Long orderId) {
+            return ApplyDiscount.builder()
+                    .userId(userId)
+                    .userCouponIds(userCouponIds)
+                    .orderId(orderId)
+                    .build();
+        }
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponEventHandler.java
@@ -1,0 +1,24 @@
+package com.loopers.domain.coupon;
+
+
+import com.loopers.domain.sharedkernel.OrderEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CouponEventHandler {
+    private final CouponService couponService;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleOrderCompleted(OrderEvent.OrderCompleted event) {
+        log.info("쿠폰 사용 처리 이벤트: orderId:{}", event.orderId());
+        couponService.applyCoupon(
+               CouponCommand.ApplyDiscount.of(event.userId(), event.userCouponIds(), event.orderId())
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCoupon.java
@@ -34,9 +34,6 @@ public class UserCoupon {
     @Column(name = "order_id", nullable = true) //발급, 사용 구분 가능 : nullable = true
     private Long orderId;
 
-    @Version
-    private Long version;
-
     @Column(name = "issued_at", nullable = false)
     private LocalDate issuedAt;
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/UserCouponRepository.java
@@ -13,4 +13,7 @@ public interface UserCouponRepository {
     List<UserCoupon> findAllByOrderIdAndUserId(Long orderId, Long userId);
 
     List<UserCoupon> findAllByOrderId(Long orderId);
+
+    List<UserCoupon> findAllByIdInAndUserIdWithLock(List<Long> userCouponIds, Long userId);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -1,35 +1,57 @@
 package com.loopers.domain.like;
 
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
+import com.loopers.domain.sharedkernel.LikeEvent;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class LikeService {
 
     private final LikeHistoryRepository likeHistoryRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public LikeHistory register(Long userId, Long productId) {
-        LikeHistory likeHistory;
-        try {
-            likeHistory = likeHistoryRepository.save(LikeHistory.from(userId, productId));
-        }catch (DataIntegrityViolationException e){
-            throw new CoreException(ErrorType.CONFLICT,"이미 좋아요를 등록한 상품입니다.");
+    @Transactional
+    public LikeQuery.LikeRegisterQuery register(Long userId, Long productId) {
+        final Optional<LikeHistory> optional = likeHistoryRepository.findByUserIdAndProductId(userId, productId);
+
+        if (optional.isPresent()) {
+            log.info("이미 좋아요가 등록되어 있습니다. userId: {}, productId: {}", userId, productId);
+            return LikeQuery.LikeRegisterQuery.alreadyRegister(optional.get());
         }
-        return likeHistory;
+
+        //todo: 저장할 때 상품의 유효성판단이 안되었음. 이벤트 발행시 상품 수 update는 0건 일 것임 -> 문제 없다고 판단하고 그냥 넘어가나?
+        //좋아요 수 증가(비동기)
+        LikeEvent.LikeCountIncreased event = new LikeEvent.LikeCountIncreased(productId);
+        eventPublisher.publishEvent(event);
+
+        final LikeHistory saved = likeHistoryRepository.save(LikeHistory.from(userId, productId));
+
+        return LikeQuery.LikeRegisterQuery.success(saved);
     }
 
-    public boolean remove(final Long userId, final Long productId) {
+    @Transactional
+    public LikeQuery.LikeRemoveQuery remove(final Long userId, final Long productId) {
         int deletedCount = likeHistoryRepository.deleteByUserIdAndProductId(userId, productId);
-        return deletedCount > 0;
+
+        if (deletedCount == 0) {
+            log.info("좋아요가 이미 해제되어 있습니다. userId: {}, productId: {}", userId, productId);
+            return LikeQuery.LikeRemoveQuery.alreadyRemoved(userId, productId);
+        }
+
+        //좋아요 수 감소(비동기)
+        LikeEvent.LikeCountDecreased event = new LikeEvent.LikeCountDecreased(productId);
+        eventPublisher.publishEvent(event);
+
+        return LikeQuery.LikeRemoveQuery.success(userId, productId);
     }
 
     public Page<LikeHistory> retrieveHistories(final Long userId, final Pageable pageable) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/Order.java
@@ -1,11 +1,11 @@
 package com.loopers.domain.order;
 
+import com.loopers.domain.BaseEntity;
 import com.loopers.domain.commonvo.Money;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;
 
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,11 +17,7 @@ import lombok.*;
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Order {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Order extends BaseEntity {
 
     private Long userId;
 
@@ -49,16 +45,11 @@ public class Order {
     @Builder.Default
     private List<OrderLine> orderLines = new ArrayList<>();
 
-    private ZonedDateTime createdAt;
-    private ZonedDateTime updatedAt;
-    private ZonedDateTime deletedAt;
-
     public static Order create(Long userId, String orderRequestId) {
         return Order.builder()
                 .userId(userId)
                 .status(OrderStatus.PENDING)
                 .orderRequestId(orderRequestId)
-                .createdAt(ZonedDateTime.now())
                 .build();
     }
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderEventHandler.java
@@ -1,0 +1,28 @@
+package com.loopers.domain.order;
+
+import com.loopers.domain.sharedkernel.PaymentEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class OrderEventHandler {
+
+    private final OrderService orderService;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleOrderCompleted(PaymentEvent.PaymentCompleted event) {
+        log.info("주문 성공 처리 이벤트: {}", event.orderId());
+        orderService.success(event.orderId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleOrderFailed(PaymentEvent.PaymentFailed event) {
+        log.info("주문 실패 처리 이벤트: orderId:{}", event.orderId());
+        orderService.markFailed(event.orderId());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/order/OrderService.java
@@ -1,10 +1,12 @@
 package com.loopers.domain.order;
 
 import com.loopers.domain.commonvo.Money;
+import com.loopers.domain.sharedkernel.OrderEvent;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,20 +18,27 @@ import java.util.List;
 @Component
 public class OrderService {
     private final OrderRepository orderRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public OrderQuery.CreatedOrder createOrderByRequestId(Long userId, String orderRequestId) {
-        return orderRepository.findByOrderRequestId(orderRequestId)
-                .map(order -> {
-                    log.info("기존 주문 발견: orderId={}, orderRequestId={}", order.getId(), orderRequestId);
-                    return OrderQuery.CreatedOrder.existing(order);
-                })
-                .orElseGet(() -> {
-                    log.info("새 주문 생성: userId={}, orderRequestId={}", userId, orderRequestId);
-                    Order createdOrder = orderRepository.save(Order.create(userId, orderRequestId));
-                    return OrderQuery.CreatedOrder.created(createdOrder);
-                });
+        Order order = orderRepository.findByOrderRequestId(orderRequestId).orElse(null);
+
+        if (order != null) {
+            log.info("기존 주문 발견: orderId={}, orderRequestId={}", order.getId(), orderRequestId);
+            return OrderQuery.CreatedOrder.existing(order);
+        }
+
+        log.info("새 주문 생성: userId={}, orderRequestId={}", userId, orderRequestId);
+        Order createdOrder = orderRepository.save(Order.create(userId, orderRequestId));
+
+        //주문 이벤트 발행
+        OrderEvent.OrderPending event = new OrderEvent.OrderPending(createdOrder.getId());
+        eventPublisher.publishEvent(event);
+
+        return OrderQuery.CreatedOrder.created(createdOrder);
     }
+
 
     public Money calculateOrderAmountByAddLines(final Order order, final List<OrderLine> orderLines) {
         order.addOrderLine(orderLines);
@@ -64,15 +73,25 @@ public class OrderService {
         return orderRepository.save(order);
     }
 
+    @Transactional
     public void markFailed(final Long orderId) {
         Order order = orderRepository.findByIdWithOrderLines(orderId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "주문 정보를 찾을 수 없습니다. orderId=" + orderId));
         order.fail();
+
+        //주문 실패 이벤트 발행
+        OrderEvent.OrderFailed event = new OrderEvent.OrderFailed(order.getId());
+        eventPublisher.publishEvent(event);
     }
 
+    @Transactional
     public void success(Long orderId) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "주문 정보를 찾을 수 없습니다. orderId=" + orderId));
         order.success();
+
+        //주문 성공 이벤트 발행
+        OrderEvent.OrderSucceeded event = new OrderEvent.OrderSucceeded(order.getId());
+        eventPublisher.publishEvent(event);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/payment/Payment.java
@@ -1,11 +1,10 @@
 package com.loopers.domain.payment;
 
+import com.loopers.domain.BaseEntity;
 import com.loopers.domain.commonvo.Money;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.persistence.*;
-
-import java.time.ZonedDateTime;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,11 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "payment")
 @Entity
-public class Payment {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Payment extends BaseEntity {
 
     @Column(name = "user_id", nullable = false, updatable = false)
     private Long userId;
@@ -43,18 +38,12 @@ public class Payment {
 //    private PaymentFailureReason failureReason;
     private String failureReason;
 
-    private ZonedDateTime createdAt;
-    private ZonedDateTime updatedAt;
-    private ZonedDateTime deletedAt;
-
-
     private Payment(Long userId, Long orderId, PaymentMethod paymentMethod, Money amount, PaymentStatus status) {
         this.userId = userId;
         this.orderId = orderId;
         this.paymentMethod = paymentMethod;
         this.amount = amount;
         this.status = status;
-        this.createdAt = ZonedDateTime.now();
     }
 
     private Payment(Long userId, Long orderId, PaymentMethod paymentMethod, Money amount, PaymentStatus status,
@@ -65,7 +54,6 @@ public class Payment {
         this.amount = amount;
         this.status = status;
         this.failureReason = failureReason;
-        this.createdAt = ZonedDateTime.now();
     }
 
     public static Payment createInit(Long userId, Long orderId, PaymentMethod paymentMethod, Money amount) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEventHandler.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductEventHandler.java
@@ -1,0 +1,31 @@
+package com.loopers.domain.product;
+
+import com.loopers.domain.sharedkernel.LikeEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class ProductEventHandler {
+
+    private final ProductService productService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handleLikeCountIncrease(LikeEvent.LikeCountIncreased event) {
+        log.info("좋아요가 새로 등록되었습니다.productId: {}", event.productId());
+        productService.increaseLikeCountAtomically(event.productId());
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Async
+    public void handleLiDecrease(LikeEvent.LikeCountDecreased event) {
+        log.info("좋아요가 해제 되었습니다.productId: {}", event.productId());
+        productService.decreaseLikeCount(event.productId());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.stream.Collectors;
 
@@ -55,12 +56,14 @@ public class ProductService {
         return query;
     }
 
-    public void increaseLikeCountAtomically(final Product product) {
-        int processCount = productRepository.updateLikeCountById(product.getId());
+    @Transactional
+    public void increaseLikeCountAtomically(final Long productId) {
+        int processCount = productRepository.updateLikeCountById(productId);
     }
 
-    public void decreaseLikeCount(final Product product) {
-        productRepository.decreaseLikeCountById(product.getId());
+    @Transactional
+    public void decreaseLikeCount(final Long productId) {
+        productRepository.decreaseLikeCountById(productId);
     }
 
     public List<Product> getProducts(List<Long> productIds) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/UserBehaviorEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/UserBehaviorEvent.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.product;
+
+import java.util.Optional;
+
+public class UserBehaviorEvent {
+
+    public record ProductView(Optional<Long> userId, Long productId) { }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/sharedkernel/LikeEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/sharedkernel/LikeEvent.java
@@ -1,0 +1,13 @@
+package com.loopers.domain.sharedkernel;
+
+public class LikeEvent {
+    public record LikeCountIncreased(
+            Long productId
+    ) {
+    }
+
+    public record LikeCountDecreased(
+            Long productId
+    ) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/sharedkernel/OrderEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/sharedkernel/OrderEvent.java
@@ -1,0 +1,24 @@
+package com.loopers.domain.sharedkernel;
+
+import com.loopers.domain.commonvo.Money;
+
+import java.util.List;
+
+public class OrderEvent {
+    public record OrderPending(Long orderId) {
+    }
+
+    public record OrderCompleted(
+            Long orderId,
+            Long userId,
+            Money orderAmount,
+            List<Long> userCouponIds
+    ) {
+    }
+
+    public record OrderSucceeded(Long orderId) {
+    }
+
+    public record OrderFailed(Long orderId) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/sharedkernel/PaymentEvent.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/sharedkernel/PaymentEvent.java
@@ -1,0 +1,12 @@
+package com.loopers.domain.sharedkernel;
+
+public class PaymentEvent {
+    public record PaymentCompleted(Long paymentId, Long orderId) {
+    }
+
+    public record PaymentFailed(Long paymentId, Long orderId) {
+    }
+
+    public record PaymentInitiated(Long paymentId, Long orderId) {
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponJpaRepository.java
@@ -1,7 +1,10 @@
 package com.loopers.infrastructure.coupon;
 
 import com.loopers.domain.coupon.UserCoupon;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
@@ -11,4 +14,8 @@ public interface UserCouponJpaRepository extends JpaRepository<UserCoupon,Long> 
     List<UserCoupon> findAllByOrderIdAndUserId(Long orderId, Long userId);
 
     List<UserCoupon> findAllByOrderId(Long orderId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT uc FROM UserCoupon uc WHERE uc.id IN :userCouponIds AND uc.userId = :userId")
+    List<UserCoupon> findAllByIdInAndUserIdWithLock(List<Long> userCouponIds, Long userId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/UserCouponRepositoryImpl.java
@@ -37,4 +37,10 @@ public class UserCouponRepositoryImpl implements UserCouponRepository {
     public List<UserCoupon> findAllByOrderId(Long orderId) {
         return userCouponJpaRepository.findAllByOrderId(orderId);
     }
+
+    @Override
+    public List<UserCoupon> findAllByIdInAndUserIdWithLock(List<Long> userCouponIds, Long userId) {
+        return userCouponJpaRepository.findAllByIdInAndUserIdWithLock(userCouponIds, userId);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/dataplatform/DataPlatformEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/dataplatform/DataPlatformEventListener.java
@@ -1,0 +1,61 @@
+package com.loopers.infrastructure.dataplatform;
+
+
+import com.loopers.domain.sharedkernel.OrderEvent;
+import com.loopers.domain.sharedkernel.PaymentEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class DataPlatformEventListener {
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePaymentCompleted(PaymentEvent.PaymentCompleted event) {
+        log.info("결제 성공 데이터전송 이벤트: orderId:{}, paymentId:{}",
+                event.orderId(), event.paymentId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePaymentFailed(PaymentEvent.PaymentFailed event) {
+        log.info("결제 실패 데이터전송 이벤트: paymentId:{}", event.paymentId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePaymentInitiated(PaymentEvent.PaymentInitiated event) {
+        log.info("결제 요청완료 데이터전송 이벤트: paymentId:{}", event.paymentId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderPending(OrderEvent.OrderPending event) {
+        log.info("주문 초기생성 데이터전송 이벤트: orderId:{}", event.orderId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderCompleted(OrderEvent.OrderCompleted event) {
+        log.info("주문 완료 데이터전송 이벤트: orderId:{}", event.orderId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderSucceeded(OrderEvent.OrderSucceeded event) {
+        log.info("주문 성공 데이터전송 이벤트: orderId:{}", event.orderId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleOrderFailed(OrderEvent.OrderFailed event) {
+        log.info("주문 실패 데이터전송 이벤트: orderId:{}", event.orderId());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/dataplatform/UserBehaviorEventListener.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/dataplatform/UserBehaviorEventListener.java
@@ -1,0 +1,33 @@
+package com.loopers.infrastructure.dataplatform;
+
+import com.loopers.domain.product.UserBehaviorEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class UserBehaviorEventListener {
+
+    /**
+     * todo: @Transactional이 없어 @TransactionalEventListener는 적용되지 않았음.
+     * fallbackExecution = true를 해주면 됨. 또는 @EventListener를 쓰던가.
+     */
+    @Async("productViewExecutor")
+    @TransactionalEventListener(
+            phase = TransactionPhase.AFTER_COMMIT,
+            fallbackExecution = true
+    )
+    public void handleProductViewEventAfterCommit(UserBehaviorEvent.ProductView event) {
+        // 데이터 플랫폼으로 전송
+        sendToDataPlatformSystem(event);
+    }
+
+    private void sendToDataPlatformSystem(UserBehaviorEvent.ProductView event) {
+        log.info("*데이터플랫폼전송:상품조회");
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiController.java
@@ -1,0 +1,34 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.domain.like.LikeQuery;
+import com.loopers.domain.like.LikeService;
+import com.loopers.interfaces.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/like")
+public class LikeV1ApiController {
+
+    private final LikeService likeService;
+
+    @PostMapping("/products/{productId}")
+    public ApiResponse<LikeV1Dto.RegisterResponse> register(
+            @RequestHeader(name = "X-USER-ID", required = true) final Long userId,
+            @PathVariable final Long productId
+    ) {
+        LikeQuery.LikeRegisterQuery query = likeService.register(userId, productId);
+        return ApiResponse.success(LikeV1Dto.RegisterResponse.from(query));
+    }
+
+    @DeleteMapping("/products/{productId}")
+    public ApiResponse<LikeV1Dto.RemoveResponse> remove(
+            @RequestHeader(name = "X-USER-ID", required = true) final Long userId,
+            @PathVariable final Long productId
+    ) {
+
+        LikeQuery.LikeRemoveQuery query = likeService.remove(userId, productId);
+        return ApiResponse.success(LikeV1Dto.RemoveResponse.from(query));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1ApiSpec.java
@@ -1,0 +1,64 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Like V1 API", description = "Like management operations")
+public interface LikeV1ApiSpec {
+
+    @Operation(
+            summary = "상품 좋아요 등록",
+            description = "헤더 X-USER-ID 로 식별된 사용자가 특정 상품에 대해 좋아요를 등록합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 등록 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "상품 또는 사용자 없음")
+    })
+    ApiResponse<LikeV1Dto.RegisterResponse> register(
+            @Parameter(
+                    name = "X-USER-ID",
+                    required = true,
+                    in = ParameterIn.HEADER,
+                    description = "사용자 식별자 (헤더)"
+            )
+            Long userId,
+            @Parameter(
+                    name = "productId",
+                    required = true,
+                    in = ParameterIn.PATH,
+                    description = "좋아요를 등록할 상품 식별자"
+            )
+            Long productId
+    );
+
+    @Operation(
+            summary = "상품 좋아요 취소",
+            description = "헤더 X-USER-ID 로 식별된 사용자가 특정 상품에 대해 등록한 좋아요를 취소합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "좋아요 취소 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "상품 또는 사용자 없음")
+    })
+    ApiResponse<LikeV1Dto.RemoveResponse> remove(
+            @Parameter(
+                    name = "X-USER-ID",
+                    required = true,
+                    in = ParameterIn.HEADER,
+                    description = "사용자 식별자 (헤더)"
+            )
+            Long userId,
+            @Parameter(
+                    name = "productId",
+                    required = true,
+                    in = ParameterIn.PATH,
+                    description = "좋아요를 취소할 상품 식별자"
+            )
+            Long productId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/like/LikeV1Dto.java
@@ -1,0 +1,39 @@
+package com.loopers.interfaces.api.like;
+
+import com.loopers.application.like.LikeResult;
+import com.loopers.domain.like.LikeQuery;
+
+public class LikeV1Dto {
+
+    public record RegisterResponse(
+            boolean isDuplicatedRequest
+    ) {
+        public static RegisterResponse from(LikeResult.LikeRegisterResult result) {
+            return new RegisterResponse(
+                    result.isDuplicatedRequest()
+            );
+        }
+
+        public static RegisterResponse from(LikeQuery.LikeRegisterQuery query) {
+            return new RegisterResponse(
+                    query.isDuplicatedRequest()
+            );
+        }
+    }
+
+    public record RemoveResponse(
+            boolean isDuplicatedRequest
+    ) {
+        public static RemoveResponse from(LikeResult.LikeRemoveResult result) {
+            return new RemoveResponse(
+                    result.isDuplicatedRequest()
+            );
+        }
+
+        public static RemoveResponse from(LikeQuery.LikeRemoveQuery query) {
+            return new RemoveResponse(
+                    query.isDuplicatedRequest()
+            );
+        }
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiController.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/order/OrderV1ApiController.java
@@ -27,9 +27,6 @@ public class OrderV1ApiController implements OrderV1ApiSpec {
         OrderInfo.Create info = request.convertToOrderInfo(userId, orderRequestKey);
         OrderResult.OrderRequestResult result = orderUseCase.order(info);
 
-        // 로그 출력
-        log.info("주문 요청 처리 완료: userId={}, orderRequestKey={}, result={}",
-                userId, orderRequestKey, result);
         return ApiResponse.success(OrderV1Response.OrderResponse.from(result));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/support/event/AsyncConfiguration.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/event/AsyncConfiguration.java
@@ -1,0 +1,81 @@
+package com.loopers.support.event;
+
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.aop.interceptor.SimpleAsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+
+@Configuration
+@EnableAsync
+public class AsyncConfiguration {
+
+    // 기본 AsyncConfigurer 구현 (선택적이지만 권장)
+    @Bean
+    public AsyncConfigurer asyncConfigurer() {
+        return new AsyncConfigurer() {
+            @Override
+            public Executor getAsyncExecutor() {
+                // 기본 async executor 설정
+                ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+                executor.setCorePoolSize(5);
+                executor.setMaxPoolSize(10);
+                executor.setQueueCapacity(25);
+                executor.setThreadNamePrefix("Default-Async-");
+                executor.initialize();
+                return executor;
+            }
+
+            @Override
+            public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+                // 비동기 예외 처리
+                return new SimpleAsyncUncaughtExceptionHandler();
+            }
+        };
+    }
+
+    // 상품 조회 전용 실행자
+    @Bean("productViewExecutor")
+    public Executor productViewExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);           // 기본 스레드 수
+        executor.setMaxPoolSize(50);            // 최대 스레드 수
+        executor.setQueueCapacity(200);         // 대기 큐 크기
+        executor.setKeepAliveSeconds(60);       // 유휴 스레드 생존 시간
+        executor.setThreadNamePrefix("ProductView-");
+
+        // 큐가 가득 찬 경우 처리 정책
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+        // 애플리케이션 종료 시 진행 중인 작업 대기
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+
+        executor.initialize();
+        return executor;
+    }
+
+    // 커스텀 예외 처리기
+    @Bean
+    public AsyncUncaughtExceptionHandler customAsyncExceptionHandler() {
+        return new AsyncUncaughtExceptionHandler() {
+            @Override
+            public void handleUncaughtException(Throwable throwable, Method method, Object... objects) {
+                System.out.println("비동기 메서드에서 예외 발생: " + method.getName());
+                System.out.println("예외: " + throwable.getMessage());
+                System.out.println("매개변수: " + Arrays.toString(objects));
+
+                // 로깅, 알림 등 추가 처리
+                // logger.error("Async method {} failed", method.getName(), throwable);
+            }
+        };
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/support/event/TransactionConfiguration.java
+++ b/apps/commerce-api/src/main/java/com/loopers/support/event/TransactionConfiguration.java
@@ -1,0 +1,9 @@
+package com.loopers.support.event;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+public class TransactionConfiguration {
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/product/ProductServiceIntegrationTest.java
@@ -347,7 +347,7 @@ class ProductServiceIntegrationTest {
                     .getLikeCount().getValue();
 
             // Act
-            sut.increaseLikeCountAtomically(product); //jpql update 쿼리 호출
+            sut.increaseLikeCountAtomically(product.getId()); //jpql update 쿼리 호출
 
             // 영속성 컨텍스트 동기화 및 캐시 초기화
             em.flush();

--- a/modules/jpa/src/main/resources/jpa.yml
+++ b/modules/jpa/src/main/resources/jpa.yml
@@ -37,7 +37,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
       properties:
         hibernate.format_sql: true
         hibernate.use_sql_comments: true


### PR DESCRIPTION
## 📌 Summary
<!--
    어떤 기능/이슈를 해결했는지 요약해주세요.
-->

## 💬 Review Points

### * Facade 를 제거해보는 접근 방식 : '좋아요 등록/해제' 유스케이스를 선택
이번주 주제는 이벤트 분리를 통해 다수 사용자의 각 작업을 독립적으로 분리하여 대용량 트래픽을 효율적으로 처리할 수 있는 시스템 구축의 기반을 마련하는 것이라 생각했습니다. 
이러한 맥락에서 여러 애그리게이트를 조율하는 Facade 를 제거해보는 접근 방식을 고려해보았습니다. 그 중에서도 가장 구현하기 쉬울 것으로 판단되는 '좋아요 등록/해제' 유스케이스를 선택하여 실험해보았습니다.

하지만 좋아요 기능에서도 Product 의존성을 완전히 제거하는 것은 예상보다 까다로웠습니다. 
왜냐면 ProductId 유효성 검증 로직이 있어야 하기 때문입니다. 검증로직이 없더라도  update/insert/delete 작업 시 WHERE productId 조건을 사용하기 때문에 DB에는 잘못된 데이터가 입력되지 않습니다.

그러나 문제는 API 응답에서 발생합니다. 실제로는 유효하지 않은 ProductId에 대한 요청임에도 불구하고 클라이언트에게는 성공한 것처럼 응답이 반환되는 상황이 발생합니다.
다음과 같은 점들에 대해 의견을 구하고 싶습니다
1. 좋아요 기능에서 상품 조회 로직을 완전히 분리하는 것이 실제로 가능한가요?
2. API 응답의 이러한 정도의 부정확성은 시스템 설계상 허용 가능한 수준인가요?
3. 파사드를 제거했을 때, 기존 구조가 망가지는 현상이 발생. 테스트코드는 어떤 식으로 작성해야 하나요? 블랙박스 테스트를 한다고 하면 어떤 layer에서 어떤 TC를 작성해야 하나요?

### * 이벤트 발행 로직의 비즈니스 로직 분리 방안
현재 비즈니스 로직에 이벤트 발행 코드가 직접 포함된 구조를 개선하고 싶습니다. 
4. 비즈니스 로직의 순수성을 유지하면서 이벤트를 적절한 시점에 발행할 수 있는 아키텍처 패턴이나 구현 방식이 있을까요?

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->