### PR TITLE
[Round10] Spring Batch 를 활용해 주간, 월간 랭킹 제공

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ out/
 # ---- Build / Generated code ----
 apps/commerce-api/src/main/generated/
 apps/commerce-streamer/src/main/generated/
+apps/commerce-batch/src/main/generated/
 
 # ---- Docker InfluxDB data ----
 docker/influxdb/

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingPeriodType.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingPeriodType.java
@@ -1,0 +1,5 @@
+package com.loopers.application.ranking;
+
+public enum RankingPeriodType {
+    DAILY, WEEKLY, MONTHLY
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingResult.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/ranking/RankingResult.java
@@ -13,10 +13,12 @@ import java.util.stream.Collectors;
 public class RankingResult {
 
     public record ListView(
+            RankingPeriodType periodType, // 일간 / 주간 / 월간
             List<ListItem> items,
             Pagination pagination
     ) {
-        public static ListView from(List<RankingQuery.RankingItem> rankingItems,
+        public static ListView from(RankingPeriodType periodType,
+                                    List<RankingQuery.RankingItem> rankingItems,
                                     List<ProductListProjection> projections,
                                     Pagination pagination) {
 
@@ -42,11 +44,14 @@ public class RankingResult {
                     })
                     .toList();
 
-            return new ListView(items, pagination);
+            return new ListView(periodType, items, pagination);
         }
 
-        public static ListView empty(int page, int size) {
+        public static ListView empty(RankingPeriodType periodType,
+                                     int page,
+                                     int size) {
             return new ListView(
+                    periodType,
                     List.of(),
                     new Pagination(page, size, 0)
             );

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MonthlyRankingMv.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/MonthlyRankingMv.java
@@ -1,0 +1,56 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(
+        name = "monthly_ranking_mv",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_monthly_ranking", columnNames = {"agg_date", "product_id"})
+        },
+        indexes = {
+                @Index(name = "idx_monthly_ranking_score", columnList = "score")
+        }
+)
+public class MonthlyRankingMv {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "agg_date", nullable = false)
+    private LocalDate aggDate;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "score", nullable = false)
+    private Double score;
+
+    @Column(name = "created_at", nullable = false,
+            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingRepository.java
@@ -6,7 +6,11 @@ import org.springframework.data.domain.Pageable;
 import java.time.LocalDate;
 
 public interface RankingRepository {
-    Page<RankingQuery.RankingItem> findAll(LocalDate date, Pageable pageable);
+    Page<RankingQuery.RankingItem> findDailyAll(LocalDate date, Pageable pageable);
 
-    Long findRankByDateAndProductId(LocalDate date, Long productId);
+    Long findDailyRankByDateAndProductId(LocalDate date, Long productId);
+
+    Page<RankingQuery.RankingItem> findWeeklyAll(LocalDate date, Pageable pageable);
+
+    Page<RankingQuery.RankingItem> findMonthlyAll(LocalDate date, Pageable pageable);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/RankingService.java
@@ -16,14 +16,32 @@ public class RankingService {
 
     private final RankingRepository rankingRepository;
 
-    public Page<RankingQuery.RankingItem> retrieve(LocalDate date, PagingCondition pagingCondition) {
+    public Page<RankingQuery.RankingItem> retrieveDaily(LocalDate date, PagingCondition pagingCondition) {
         Pageable pageable = pagingCondition.toPageable();
-        Page<RankingQuery.RankingItem> rankingItems = rankingRepository.findAll(date, pageable);
+        Page<RankingQuery.RankingItem> rankingItems = rankingRepository.findDailyAll(date, pageable);
 
         return rankingItems;
     }
 
-    public Long retrieveRankByDateAndProductId(LocalDate date, Long productId) {
-        return rankingRepository.findRankByDateAndProductId(date, productId);
+    public Long retrieveRankByDateAndProductId(final LocalDate date, final Long productId) {
+        return rankingRepository.findDailyRankByDateAndProductId(date, productId);
+    }
+
+    public Page<RankingQuery.RankingItem> retrieveWeekly(final LocalDate date, final PagingCondition pagingCondition) {
+        final Page<RankingQuery.RankingItem> weeklyAll = rankingRepository.findWeeklyAll(date, pagingCondition.toPageable());
+        if (!weeklyAll.isEmpty()) {
+            return weeklyAll;
+        }
+
+        return rankingRepository.findWeeklyAll(date.minusDays(1), pagingCondition.toPageable());
+    }
+
+    public Page<RankingQuery.RankingItem> retrieveMonthly(final LocalDate date, final PagingCondition pagingCondition) {
+        final Page<RankingQuery.RankingItem> monthlyAll = rankingRepository.findMonthlyAll(date, pagingCondition.toPageable());
+        if (!monthlyAll.isEmpty()) {
+            return monthlyAll;
+        }
+
+        return rankingRepository.findMonthlyAll(date.minusDays(1), pagingCondition.toPageable());
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/ranking/WeeklyRankingMv.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/ranking/WeeklyRankingMv.java
@@ -1,0 +1,56 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(
+        name = "weekly_ranking_mv",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_weekly_ranking", columnNames = {"agg_date", "product_id"})
+        },
+        indexes = {
+                @Index(name = "idx_weekly_ranking_score", columnList = "score")
+        }
+)
+public class WeeklyRankingMv {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "agg_date", nullable = false)
+    private LocalDate aggDate;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "score", nullable = false)
+    private Double score;
+
+    @Column(name = "created_at", nullable = false,
+            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingMvJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingMvJpaRepository.java
@@ -1,0 +1,13 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MonthlyRankingMv;
+import com.loopers.domain.ranking.RankingQuery;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+public interface MonthlyRankingMvJpaRepository extends JpaRepository<MonthlyRankingMv, Long> {
+    Page<MonthlyRankingMv> allByAggDateOrderByScoreDescProductIdAsc(LocalDate date, Pageable pageable);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRedisRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/RankingRedisRepository.java
@@ -27,7 +27,7 @@ public class RankingRedisRepository {
     /**
      * 특정 상품의 순위 조회 (0 = 1위): +1 해서 API에선 "1위, 2위..."로 표현
      */
-    public Long findRankByDateAndProductId(LocalDate date, Long productId) {
+    public Long findDailyRankByDateAndProductId(LocalDate date, Long productId) {
         String key = RankingKeyUtils.generateRankingKey(date);
         String member = RankingKeyUtils.generateMemberKey(productId);
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingMvJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingMvJpaRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.WeeklyRankingMv;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+
+public interface WeeklyRankingMvJpaRepository extends JpaRepository<WeeklyRankingMv, Long> {
+    Page<WeeklyRankingMv> allByAggDateOrderByScoreDescProductIdAsc(LocalDate date, Pageable pageable);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1ApiSpec.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDate;
 
@@ -26,6 +27,13 @@ public interface RankingV1ApiSpec {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청")
     })
     ApiResponse<RankingV1Dto.ListViewResponse> retrieveRanking(
+            @Parameter(
+                    name = "periodType",
+                    required = true,
+                    in = ParameterIn.QUERY,
+                    description = "랭킹 구분 (일간, 주간, 월간)"
+            )
+            @RequestParam RankingV1Dto.RankingPeriodType periodType,
             @Parameter(
                     name = "date",
                     required = true,

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Controller.java
@@ -1,6 +1,7 @@
 package com.loopers.interfaces.api.ranking;
 
 import com.loopers.application.common.PagingCondition;
+import com.loopers.application.ranking.RankingPeriodType;
 import com.loopers.application.ranking.RankingResult;
 import com.loopers.application.ranking.RankingUseCase;
 import com.loopers.interfaces.api.ApiResponse;
@@ -16,17 +17,19 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/rankings")
 @RestController
-public class RankingV1Controller implements RankingV1ApiSpec{
+public class RankingV1Controller implements RankingV1ApiSpec {
 
     private final RankingUseCase rankingUseCase;
 
     @GetMapping
     @Override
     public ApiResponse<RankingV1Dto.ListViewResponse> retrieveRanking(
+            @RequestParam(required = true, defaultValue = "DAILY") RankingV1Dto.RankingPeriodType periodType,
             @RequestParam(required = true) @DateTimeFormat(pattern = "yyyyMMdd") LocalDate date,
-            @Valid @ModelAttribute PagingCondition pagingCondition)
-    {
-        RankingResult.ListView result = rankingUseCase.retrieveRanking(date, pagingCondition);
+            @Valid @ModelAttribute PagingCondition pagingCondition) {
+        RankingResult.ListView result = rankingUseCase.retrieveRanking(
+                RankingPeriodType.valueOf(periodType.name()), date, pagingCondition
+        );
         return ApiResponse.success(RankingV1Dto.ListViewResponse.from(result));
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/ranking/RankingV1Dto.java
@@ -13,6 +13,7 @@ public class RankingV1Dto {
 
     public record ListViewRequest(
             LocalDate date,  // yyyyMMdd 포맷
+            RankingV1Dto.RankingPeriodType periodType, // 일간 / 주간 / 월간
             @Nullable
             PagingCondition pagingCondition
     ) {
@@ -24,6 +25,7 @@ public class RankingV1Dto {
     }
 
     public record ListViewResponse(
+            RankingV1Dto.RankingPeriodType periodType, // 일간 / 주간 / 월간
             List<RankingItemResponse> rankings,
             PaginationResponse pagination
     ) {
@@ -43,7 +45,10 @@ public class RankingV1Dto {
                     ))
                     .toList();
 
-            return new ListViewResponse(items, PaginationResponse.from(result.pagination()));
+            return new ListViewResponse(
+                    RankingV1Dto.RankingPeriodType.valueOf(result.periodType().name()),
+                    items,
+                    PaginationResponse.from(result.pagination()));
         }
     }
 
@@ -82,5 +87,9 @@ public class RankingV1Dto {
                     pagination.page() >= totalPages - 1
             );
         }
+    }
+
+    public enum RankingPeriodType {
+        DAILY, WEEKLY, MONTHLY
     }
 }

--- a/apps/commerce-batch/build.gradle.kts
+++ b/apps/commerce-batch/build.gradle.kts
@@ -1,0 +1,24 @@
+dependencies {
+    // add-ons
+    implementation(project(":modules:jpa"))
+    implementation(project(":modules:redis"))
+    implementation(project(":modules:kafka"))
+    implementation(project(":supports:jackson"))
+    implementation(project(":supports:logging"))
+    implementation(project(":supports:monitoring"))
+
+    // web
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // querydsl
+    annotationProcessor("com.querydsl:querydsl-apt::jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+
+    // spring batch
+    implementation("org.springframework.boot:spring-boot-starter-batch")
+
+    // test-fixtures
+    testImplementation(testFixtures(project(":modules:jpa")))
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/CommerceBatchApplication.java
@@ -1,0 +1,11 @@
+package com.loopers;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class CommerceBatchApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(CommerceBatchApplication.class, args);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingProcessor.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingProcessor.java
@@ -1,0 +1,35 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.RankingResult;
+import com.loopers.domain.weeklymetrics.ProductMetricsWeekly;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+
+@Component
+public class MonthlyRankingProcessor implements ItemProcessor<ProductMetricsWeekly, RankingResult> {
+
+    @Override
+    public RankingResult process(ProductMetricsWeekly item) {
+        // 1. raw score 계산
+        double rawScore = (item.getLikeCount() * 1)
+                + (item.getPurchaseCount() * 5)
+                + (item.getViewCount() * 0.2);
+
+        // 2. 날짜 가중치 (aggDate(=WindowEnd) 기준)
+        long daysAgo = ChronoUnit.DAYS.between(item.getWindowEnd(), LocalDate.now());
+        double weight = Math.max(0.4, 1.0 - (daysAgo * 0.1));
+
+        // 3. 최종 점수 (가중치 반영)
+        double weightedScore = rawScore * weight;
+
+        return new RankingResult(
+                item.getProductId(),
+                item.getWindowEnd(),
+                weightedScore
+        );
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingReader.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingReader.java
@@ -1,0 +1,61 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.weeklymetrics.ProductMetricsWeekly;
+import com.loopers.infrastructure.weeklymetrics.ProductMetricsWeeklyJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class MonthlyRankingReader implements ItemReader<ProductMetricsWeekly> {
+
+    private final ProductMetricsWeeklyJpaRepository repository;
+
+    @Value("#{jobParameters['targetDate']}")
+    private String targetDateStr;
+
+    private RepositoryItemReader<ProductMetricsWeekly> delegate;
+
+    private boolean initialized = false;
+
+    private void init() {
+        LocalDate targetDate = LocalDate.parse(targetDateStr);
+
+        List<LocalDate> windowEndDates = List.of(
+                targetDate.minusWeeks(3),
+                targetDate.minusWeeks(2),
+                targetDate.minusWeeks(1),
+                targetDate
+        );
+
+        this.delegate = new RepositoryItemReaderBuilder<ProductMetricsWeekly>()
+                .name("monthlyRankingReader")
+                .repository(repository)
+                .methodName("findAllByWindowEndIn")
+                .arguments(List.of(windowEndDates))
+                .pageSize(50)
+                .sorts(Map.of("id", Sort.Direction.ASC))
+                .build();
+
+        initialized = true;
+    }
+
+    @Override
+    public ProductMetricsWeekly read() throws Exception {
+        if (!initialized) {
+            init();
+        }
+        return delegate.read();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingWriter.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/MonthlyRankingWriter.java
@@ -1,0 +1,23 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.MonthlyRankingService;
+import com.loopers.domain.ranking.RankingResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyRankingWriter implements ItemWriter<RankingResult> {
+
+    private final MonthlyRankingService monthlyRankingService;
+
+    @Override
+    public void write(Chunk<? extends RankingResult> chunk) {
+        // MonthlyRankingService를 통해 저장 처리
+        monthlyRankingService.saveAll((List<RankingResult>) chunk.getItems());
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingService.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/ranking/WeeklyRankingService.java
@@ -1,0 +1,31 @@
+package com.loopers.application.ranking;
+
+import com.loopers.domain.ranking.RankingResult;
+import com.loopers.domain.ranking.WeeklyRankingMvRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+public class WeeklyRankingService {
+
+    private final WeeklyRankingMvRepository weeklyRankingMvRepository;
+
+    @Transactional
+    public void saveAll(List<RankingResult> items) {
+        Map<Long, Double> scoreByProduct = new HashMap<>();
+        for (RankingResult r : items) {
+            scoreByProduct.merge(r.getProductId(), r.getScore(), Double::sum);
+        }
+
+        LocalDate today = LocalDate.now();
+        scoreByProduct.forEach((productId, score) ->
+                weeklyRankingMvRepository.upsert(today, productId, score));
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/weeklymetrics/ProductMetricsReaderFactory.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/weeklymetrics/ProductMetricsReaderFactory.java
@@ -1,0 +1,48 @@
+package com.loopers.application.weeklymetrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.infrastructure.metrics.ProductMetricsJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.data.domain.Sort;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class ProductMetricsReaderFactory {
+
+    public static final int PAGE_SIZE = 2;
+    public static final int DAYS_TO_SUBTRACT = 6;
+
+    private final ProductMetricsJpaRepository productMetricsRepository;
+
+    @Bean(name = "productMetricsReader")
+    @StepScope
+    public ItemReader<ProductMetrics> productMetricsReader(
+            @Value("#{jobParameters['toDate']}") String toDateStr
+    ) {
+        LocalDate to = LocalDate.parse(toDateStr, DateTimeFormatter.ISO_DATE);
+        LocalDate from = to.minusDays(DAYS_TO_SUBTRACT);
+
+        return new RepositoryItemReaderBuilder<ProductMetrics>()
+                .name("productMetricsReader") // Bean 이름과 동일하게
+                .repository(productMetricsRepository)
+                .methodName("findAllByMetricsDateBetween")
+                .arguments(Arrays.asList(from, to))
+                .pageSize(PAGE_SIZE)
+                .sorts(Map.of(
+                        "productId", Sort.Direction.ASC,
+                        "metricsDate", Sort.Direction.ASC
+                ))
+                .build();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/application/weeklymetrics/WeeklyMetricsWriter.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/application/weeklymetrics/WeeklyMetricsWriter.java
@@ -1,0 +1,40 @@
+package com.loopers.application.weeklymetrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.weeklymetrics.WeeklyMetricsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class WeeklyMetricsWriter implements ItemWriter<ProductMetrics>, StepExecutionListener {
+
+    private final WeeklyMetricsService weeklyMetricsService;
+    private LocalDate to;
+    private LocalDate from;
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        String toDateStr = stepExecution.getJobParameters().getString("toDate");
+        this.to = LocalDate.parse(toDateStr);
+        this.from = to.minusDays(6);
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        return ExitStatus.COMPLETED;
+    }
+
+    @Override
+    public void write(Chunk<? extends ProductMetrics> items) {
+        weeklyMetricsService.aggregateAndSave((List<ProductMetrics>) items.getItems(), from, to);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetrics.java
@@ -1,0 +1,72 @@
+package com.loopers.domain.metrics;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "product_metrics",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_product_date", columnNames = {"product_id", "metrics_date"})
+        },
+        indexes = {
+                @Index(name = "idx_product", columnList = "product_id"),
+                @Index(name = "idx_metrics_date", columnList = "metrics_date")
+        }
+)
+public class ProductMetrics {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 어떤 상품의 지표인지 */
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    /** 어떤 날짜의 지표인지 (일자 기준, 시간 제외) */
+    @Column(name = "metrics_date", nullable = false)
+    private LocalDate metricsDate;
+
+    /** 일별 좋아요 수 */
+    @Column(name = "like_count", nullable = false)
+    private Long likeCount;
+
+    /** 일별 판매 수 */
+    @Column(name = "purchase_count", nullable = false)
+    private Long purchaseCount;
+
+    /** 일별 조회 수 */
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount;
+
+    /** 생성 시각 */
+    @Column(name = "created_at", nullable = false,
+            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    /** 수정 시각 */
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/metrics/ProductMetricsRepository.java
@@ -1,0 +1,10 @@
+package com.loopers.domain.metrics;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+
+public interface ProductMetricsRepository {
+    Page<ProductMetrics> findByMetricsDateBetween(LocalDate from, LocalDate to, Pageable pageable);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyRankingMv.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyRankingMv.java
@@ -1,0 +1,56 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(
+        name = "monthly_ranking_mv",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_monthly_ranking", columnNames = {"agg_date", "product_id"})
+        },
+        indexes = {
+                @Index(name = "idx_monthly_ranking_score", columnList = "score")
+        }
+)
+public class MonthlyRankingMv {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "agg_date", nullable = false)
+    private LocalDate aggDate;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "score", nullable = false)
+    private Double score;
+
+    @Column(name = "created_at", nullable = false,
+            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyRankingService.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/MonthlyRankingService.java
@@ -1,0 +1,33 @@
+package com.loopers.domain.ranking;
+
+import com.loopers.infrastructure.ranking.MonthlyRankingMvJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+public class MonthlyRankingService {
+    private final MonthlyRankingMvJpaRepository monthlyRankingMvRepository;
+
+    @Transactional
+    public void saveAll(List<RankingResult> items) {
+        // productId 별 점수 합산
+        Map<Long, Double> scoreByProduct = new HashMap<>();
+        for (RankingResult r : items) {
+            scoreByProduct.merge(r.getProductId(), r.getScore(), Double::sum);
+        }
+
+        // 집계 기준일 (오늘 날짜)
+        LocalDate today = LocalDate.now();
+
+        // upsert 실행
+        scoreByProduct.forEach((productId, score) ->
+                monthlyRankingMvRepository.upsert(today, productId, score));
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingResult.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/RankingResult.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.ranking;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+public class RankingResult {
+    private Long productId;
+    private LocalDate aggDate;
+    private double score;
+    private int rankNo;
+
+    public RankingResult(Long productId, LocalDate aggDate, double score) {
+        this.productId = productId;
+        this.aggDate = aggDate;
+        this.score = score;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyRankingMv.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyRankingMv.java
@@ -1,0 +1,56 @@
+package com.loopers.domain.ranking;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(
+        name = "weekly_ranking_mv",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_weekly_ranking", columnNames = {"agg_date", "product_id"})
+        },
+        indexes = {
+                @Index(name = "idx_weekly_ranking_score", columnList = "score")
+        }
+)
+public class WeeklyRankingMv {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "agg_date", nullable = false)
+    private LocalDate aggDate;
+
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    @Column(name = "score", nullable = false)
+    private Double score;
+
+    @Column(name = "created_at", nullable = false,
+            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyRankingMvRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/ranking/WeeklyRankingMvRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.ranking;
+
+import java.time.LocalDate;
+
+public interface WeeklyRankingMvRepository {
+    int upsert(LocalDate aggDate, Long productId, Double score);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/weeklymetrics/ProductMetricsWeekly.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/weeklymetrics/ProductMetricsWeekly.java
@@ -1,0 +1,92 @@
+package com.loopers.domain.weeklymetrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(
+        name = "product_metrics_weekly",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_product_window_end",
+                        columnNames = {"product_id", "window_end"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_product", columnList = "product_id"),
+                @Index(name = "idx_window_end", columnList = "window_end")
+        }
+)
+public class ProductMetricsWeekly {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 상품 ID */
+    @Column(name = "product_id", nullable = false)
+    private Long productId;
+
+    /** 집계 윈도우 시작일 */
+    @Column(name = "window_start", nullable = false)
+    private LocalDate windowStart;
+
+    /** 집계 윈도우 종료일 (= 기준일) */
+    @Column(name = "window_end", nullable = false)
+    private LocalDate windowEnd;
+
+    /** 7일 합산 좋아요 수 */
+    @Column(name = "like_count", nullable = false)
+    private Long likeCount;
+
+    /** 7일 합산 주문 수 */
+    @Column(name = "purchase_count", nullable = false)
+    private Long purchaseCount;
+
+    /** 7일 합산 조회 수 */
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount;
+
+    /** 생성일 */
+    @Column(name = "created_at", nullable = false,
+            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    /** 수정일 */
+    @Column(name = "updated_at", nullable = false,
+            columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public static ProductMetricsWeekly from(ProductMetricsWeeklyCommand.Create command) {
+        return ProductMetricsWeekly.builder()
+                .productId(command.productId())
+                .windowStart(command.windowStart())
+                .windowEnd(command.windowEnd())
+                .likeCount(command.likeCount())
+                .purchaseCount(command.purchaseCount())
+                .viewCount(command.viewCount())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/weeklymetrics/ProductMetricsWeeklyCommand.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/weeklymetrics/ProductMetricsWeeklyCommand.java
@@ -1,0 +1,15 @@
+package com.loopers.domain.weeklymetrics;
+
+import java.time.LocalDate;
+
+public class ProductMetricsWeeklyCommand {
+    public record Create(
+            Long productId,
+            Long viewCount,
+            Long likeCount,
+            Long purchaseCount,
+            LocalDate windowStart,
+            LocalDate windowEnd
+    ) {
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/domain/weeklymetrics/WeeklyMetricsService.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/domain/weeklymetrics/WeeklyMetricsService.java
@@ -1,0 +1,42 @@
+package com.loopers.domain.weeklymetrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.infrastructure.weeklymetrics.ProductMetricsWeeklyJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class WeeklyMetricsService {
+
+    private final ProductMetricsWeeklyJpaRepository repository;
+
+    public void aggregateAndSave(List<ProductMetrics> metricsList, LocalDate from, LocalDate to) {
+        // productId별 그룹핑
+        Map<Long, List<ProductMetrics>> grouped =
+                metricsList.stream().collect(Collectors.groupingBy(ProductMetrics::getProductId));
+
+        grouped.forEach((productId, list) -> {
+            long totalView = list.stream().mapToLong(ProductMetrics::getViewCount).sum();
+            long totalPurchase = list.stream().mapToLong(ProductMetrics::getPurchaseCount).sum();
+            long totalLike = list.stream().mapToLong(ProductMetrics::getLikeCount).sum();
+
+            // ✅ ProductMetricsWeekly 엔티티 생성
+            ProductMetricsWeekly weekly = ProductMetricsWeekly.from(
+                    new ProductMetricsWeeklyCommand.Create(
+                            productId, totalView, totalLike, totalPurchase, from, to
+                    )
+            );
+
+            // ✅ 통째로 넘겨줌
+            repository.upsert(weekly);
+        });
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsJpaRepository.java
@@ -1,0 +1,18 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+import java.time.LocalDate;
+
+/*
+JpaRepository 자체가 이미 PagingAndSortingRepository를 상속하므로, 사실 뒤에 PagingAndSortingRepository를 붙일 필요는 없습니다.
+다만 이렇게 하면 IDE가 더 명확히 인식합니다.
+ */
+public interface ProductMetricsJpaRepository extends JpaRepository<ProductMetrics, Long>, PagingAndSortingRepository<ProductMetrics, Long> {
+
+    Page<ProductMetrics> findAllByMetricsDateBetween(LocalDate from, LocalDate to, Pageable pageable);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/metrics/ProductMetricsRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.loopers.infrastructure.metrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.metrics.ProductMetricsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+
+
+@RequiredArgsConstructor
+@Repository
+public class ProductMetricsRepositoryImpl implements ProductMetricsRepository {
+    private final ProductMetricsJpaRepository productMetricsJpaRepository;
+
+    @Override
+    public Page<ProductMetrics> findByMetricsDateBetween(LocalDate from, LocalDate to, Pageable pageable) {
+        return productMetricsJpaRepository.findAllByMetricsDateBetween(from, to, pageable);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingMvJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/MonthlyRankingMvJpaRepository.java
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.MonthlyRankingMv;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+
+public interface MonthlyRankingMvJpaRepository extends JpaRepository<MonthlyRankingMv, Long> {
+
+
+    @Modifying
+    @Query(value = """
+        INSERT INTO monthly_ranking_mv (agg_date, product_id, score)
+        VALUES (:aggDate, :productId, :score)
+        ON DUPLICATE KEY UPDATE score = score + VALUES(score)
+    """, nativeQuery = true)
+    int upsert(@Param("aggDate") LocalDate aggDate,
+               @Param("productId") Long productId,
+               @Param("score") Double score);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingMvJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingMvJpaRepository.java
@@ -1,0 +1,22 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.WeeklyRankingMv;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+
+public interface WeeklyRankingMvJpaRepository extends JpaRepository<WeeklyRankingMv, Long> {
+
+    @Modifying
+    @Query(value = """
+        INSERT INTO weekly_ranking_mv (agg_date, product_id, score)
+        VALUES (:aggDate, :productId, :score)
+        ON DUPLICATE KEY UPDATE score = score + VALUES(score)
+    """, nativeQuery = true)
+    int upsert(@Param("aggDate") LocalDate aggDate,
+                @Param("productId") Long productId,
+                @Param("score") Double score);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingMvRepositoryImpl.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/ranking/WeeklyRankingMvRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.ranking;
+
+import com.loopers.domain.ranking.WeeklyRankingMvRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+
+@RequiredArgsConstructor
+@Repository
+public class WeeklyRankingMvRepositoryImpl implements WeeklyRankingMvRepository {
+
+    private final WeeklyRankingMvJpaRepository weeklyRankingMvJpaRepository;
+
+    @Override
+    public int upsert(LocalDate aggDate, Long productId, Double score) {
+        return weeklyRankingMvJpaRepository.upsert(aggDate, productId, score);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/weeklymetrics/ProductMetricsWeeklyJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/weeklymetrics/ProductMetricsWeeklyJpaRepository.java
@@ -1,10 +1,15 @@
 package com.loopers.infrastructure.weeklymetrics;
 
 import com.loopers.domain.weeklymetrics.ProductMetricsWeekly;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface ProductMetricsWeeklyJpaRepository extends JpaRepository<ProductMetricsWeekly, Long> {
 
@@ -20,4 +25,6 @@ public interface ProductMetricsWeeklyJpaRepository extends JpaRepository<Product
         updated_at      = NOW()
     """, nativeQuery = true)
     void upsert(@Param("w") ProductMetricsWeekly w);
+
+    Page<ProductMetricsWeekly> findAllByWindowEndIn(List<LocalDate> windowEndDates, Pageable pageable);
 }

--- a/apps/commerce-batch/src/main/java/com/loopers/infrastructure/weeklymetrics/ProductMetricsWeeklyJpaRepository.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/infrastructure/weeklymetrics/ProductMetricsWeeklyJpaRepository.java
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.weeklymetrics;
+
+import com.loopers.domain.weeklymetrics.ProductMetricsWeekly;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ProductMetricsWeeklyJpaRepository extends JpaRepository<ProductMetricsWeekly, Long> {
+
+    @Modifying
+    @Query(value = """
+    INSERT INTO product_metrics_weekly 
+        (product_id, window_start, window_end, like_count, purchase_count, view_count, created_at, updated_at)
+    VALUES (:#{#w.productId}, :#{#w.windowStart}, :#{#w.windowEnd}, :#{#w.likeCount}, :#{#w.purchaseCount}, :#{#w.viewCount}, NOW(), NOW())
+    ON DUPLICATE KEY UPDATE
+        like_count      = product_metrics_weekly.like_count + VALUES(like_count),
+        purchase_count  = product_metrics_weekly.purchase_count + VALUES(purchase_count),
+        view_count      = product_metrics_weekly.view_count + VALUES(view_count),
+        updated_at      = NOW()
+    """, nativeQuery = true)
+    void upsert(@Param("w") ProductMetricsWeekly w);
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/job/monthlyranking/MonthlyRankingJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/job/monthlyranking/MonthlyRankingJobConfig.java
@@ -1,0 +1,51 @@
+package com.loopers.job.monthlyranking;
+
+import com.loopers.application.ranking.MonthlyRankingReader;
+import com.loopers.application.ranking.MonthlyRankingWriter;
+import com.loopers.domain.ranking.RankingResult;
+import com.loopers.domain.weeklymetrics.ProductMetricsWeekly;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+
+@Configuration
+@RequiredArgsConstructor
+public class MonthlyRankingJobConfig {
+
+    public static final int CHUNK_SIZE = 50;
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    @Bean
+    public Job monthlyRankingJob(Step monthlyRankingStep) {
+        return new JobBuilder("monthlyRankingJob", jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(monthlyRankingStep)
+                .build();
+    }
+
+    @Bean
+    public Step monthlyRankingStep(
+            MonthlyRankingReader monthlyRankingReader,
+            ItemProcessor<ProductMetricsWeekly, RankingResult> monthlyRankingProcessor,
+            MonthlyRankingWriter monthlyRankingWriter
+    ) {
+        return new StepBuilder("monthlyRankingStep", jobRepository)
+                .<ProductMetricsWeekly, RankingResult>chunk(CHUNK_SIZE, transactionManager)
+                .reader(monthlyRankingReader)
+                .processor(monthlyRankingProcessor)
+                .writer(monthlyRankingWriter)
+                .allowStartIfComplete(true)
+                .build();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/job/monthlyranking/MonthlyRankingScheduler.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/job/monthlyranking/MonthlyRankingScheduler.java
@@ -1,0 +1,40 @@
+package com.loopers.job.monthlyranking;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MonthlyRankingScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job monthlyRankingJob;
+
+    // 매시 10분에 실행
+    @Scheduled(cron = "0 58 * * * *")
+    public void runMonthlyRankingJob() {
+        try {
+            String targetDate = LocalDate.of(2025, 7, 31).toString();
+
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("targetDate", targetDate)
+                    .addLong("timestamp", System.currentTimeMillis()) // 중복 실행 방지
+                    .toJobParameters();
+
+            log.info("Starting monthlyRankingJob with targetDate={}", targetDate);
+            jobLauncher.run(monthlyRankingJob, jobParameters);
+        } catch (Exception e) {
+            log.error("Failed to run monthlyRankingJob", e);
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/job/weeklymetrics/WeeklyMetricsJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/job/weeklymetrics/WeeklyMetricsJobConfig.java
@@ -1,0 +1,73 @@
+package com.loopers.job.weeklymetrics;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.infrastructure.weeklymetrics.ProductMetricsWeeklyJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class WeeklyMetricsJobConfig {
+
+    public static final int CHUNK_SIZE = 2;
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    private final ProductMetricsWeeklyJpaRepository productMetricsWeeklyRepository;
+
+    @Bean
+    public Job weeklyMetricsJob(Step weeklyMetricsStep) {
+        return new JobBuilder("weeklyMetricsJob", jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(weeklyMetricsStep)
+                .build();
+    }
+
+    @Bean
+    public Step weeklyMetricsStep(
+            @Qualifier("productMetricsReader") ItemReader<ProductMetrics> reader,
+            ItemProcessor<ProductMetrics, ProductMetrics> processor,
+            ItemWriter<ProductMetrics> weeklyMetricsWriter
+    ) {
+        return new StepBuilder("weeklyMetricsStep", jobRepository)
+                .<ProductMetrics, ProductMetrics>chunk(CHUNK_SIZE, transactionManager)
+                .reader(reader)
+                .processor(processor)
+                .writer(weeklyMetricsWriter)
+                .allowStartIfComplete(true)
+                .build();
+    }
+
+
+    // Processor만 유지 (Reader는 Factory에서 관리)
+/*    @Bean
+    @StepScope
+    public ItemProcessor<ProductMetrics, ProductMetricsWeekly> productMetricsProcessor(
+            @Value("#{jobParameters['toDate']}") String toDateStr
+    ) {
+        var to = java.time.LocalDate.parse(toDateStr);
+        var from = to.minusDays(6);
+
+        return metrics -> ProductMetricsWeekly.from(metrics, from, to);
+    }*/
+
+    @Bean
+    @StepScope
+    public ItemProcessor<ProductMetrics, ProductMetrics> productMetricsProcessor() {
+        // 읽은 데이터를 그대로 Writer로 전달
+        return item -> item;
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/job/weeklymetrics/WeeklyMetricsScheduler.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/job/weeklymetrics/WeeklyMetricsScheduler.java
@@ -19,9 +19,9 @@ public class WeeklyMetricsScheduler {
     private final JobLauncher jobLauncher;
     private final Job weeklyMetricsJob;
 
-    @Scheduled(cron = "0 30 * * * *") // 매시 10분
+    @Scheduled(cron = "0 52 * * * *") // 매시 10분
     public void runJob() throws Exception {
-        String toDate = LocalDate.of(2025, 7, 9).toString();
+        String toDate = LocalDate.of(2025, 7, 31).toString();
 
         JobParameters jobParameters = new JobParametersBuilder()
                 .addString("toDate", toDate)    // 필수 : job Parameter 설정

--- a/apps/commerce-batch/src/main/java/com/loopers/job/weeklymetrics/WeeklyMetricsScheduler.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/job/weeklymetrics/WeeklyMetricsScheduler.java
@@ -1,0 +1,33 @@
+package com.loopers.job.weeklymetrics;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.LocalDate;
+@Configuration
+@EnableScheduling
+@RequiredArgsConstructor
+public class WeeklyMetricsScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job weeklyMetricsJob;
+
+    @Scheduled(cron = "0 30 * * * *") // 매시 10분
+    public void runJob() throws Exception {
+        String toDate = LocalDate.of(2025, 7, 9).toString();
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("toDate", toDate)    // 필수 : job Parameter 설정
+                .addLong("run.id", System.currentTimeMillis())
+                .toJobParameters();
+
+        jobLauncher.run(weeklyMetricsJob, jobParameters);
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/job/weeklyranking/WeeklyRankingJobConfig.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/job/weeklyranking/WeeklyRankingJobConfig.java
@@ -1,0 +1,52 @@
+package com.loopers.job.weeklyranking;
+
+import com.loopers.application.ranking.WeeklyRankingService;
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.ranking.RankingResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WeeklyRankingJobConfig {
+
+    public static final int CHUNK_SIZE = 2;
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final WeeklyRankingService weeklyRankingService;
+
+    @Bean
+    public Job weeklyRankingJob(Step weeklyRankingStep) {
+        return new JobBuilder("weeklyRankingJob", jobRepository)
+                .incrementer(new RunIdIncrementer())  // todo: 삭제 예정. 매번 다른 run.id 부여
+                .start(weeklyRankingStep)
+                .build();
+    }
+
+    @Bean
+    public Step weeklyRankingStep(
+            @Qualifier("productMetricsReader") ItemReader<ProductMetrics> reader,
+            ItemProcessor<ProductMetrics, RankingResult> processor
+    ) {
+        return new StepBuilder("weeklyRankingStep", jobRepository)
+                .<ProductMetrics, RankingResult>chunk(CHUNK_SIZE, transactionManager)
+                .reader(reader) // Factory에서 제공하는 공통 Reader 주입
+                .processor(processor)
+                .writer(items -> weeklyRankingService.saveAll((List<RankingResult>) items.getItems()))
+                .allowStartIfComplete(true)   // todo: 임시 추가
+                .build();
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/job/weeklyranking/WeeklyRankingProcessor.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/job/weeklyranking/WeeklyRankingProcessor.java
@@ -1,0 +1,32 @@
+package com.loopers.job.weeklyranking;
+
+import com.loopers.domain.metrics.ProductMetrics;
+import com.loopers.domain.ranking.RankingResult;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+@Component
+public class WeeklyRankingProcessor implements ItemProcessor<ProductMetrics, RankingResult> {
+
+    @Override
+    public RankingResult process(ProductMetrics item) {
+        // 1. raw score 계산
+        double rawScore = (item.getLikeCount() * 1)
+                + (item.getPurchaseCount() * 5)
+                + (item.getViewCount() * 0.2);
+
+        // 2. 날짜 가중치 계산
+        long daysAgo = ChronoUnit.DAYS.between(item.getMetricsDate(), LocalDate.now());
+        double weight = Math.max(0.4, 1.0 - (daysAgo * 0.1)); // 선형 감소, 최소 0.4
+
+        // 3. 최종 점수 반환
+        return new RankingResult(
+                item.getProductId(),
+                item.getMetricsDate(),
+                rawScore * weight
+        );
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/job/weeklyranking/WeeklyRankingScheduler.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/job/weeklyranking/WeeklyRankingScheduler.java
@@ -1,0 +1,39 @@
+package com.loopers.job.weeklyranking;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class WeeklyRankingScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job weeklyRankingJob;
+
+    /**
+     * 매 시 1분(예: 10:01, 11:01, 12:01...)에 실행
+     */
+    @Scheduled(cron = "0 44 * * * *")
+    public void runWeeklyRankingJob() {
+        try {
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addLong("timestamp", System.currentTimeMillis()) // 매 실행마다 다른 파라미터
+                    .toJobParameters();
+
+            log.info("Starting weeklyRankingJob with parameters: {}", jobParameters);
+            jobLauncher.run(weeklyRankingJob, jobParameters);
+        } catch (Exception e) {
+            log.error("Failed to run weeklyRankingJob", e);
+        }
+    }
+}

--- a/apps/commerce-batch/src/main/java/com/loopers/job/weeklyranking/WeeklyRankingScheduler.java
+++ b/apps/commerce-batch/src/main/java/com/loopers/job/weeklyranking/WeeklyRankingScheduler.java
@@ -23,7 +23,7 @@ public class WeeklyRankingScheduler {
     /**
      * 매 시 1분(예: 10:01, 11:01, 12:01...)에 실행
      */
-    @Scheduled(cron = "0 44 * * * *")
+    @Scheduled(cron = "0 50 * * * *")
     public void runWeeklyRankingJob() {
         try {
             JobParameters jobParameters = new JobParametersBuilder()

--- a/apps/commerce-batch/src/main/resources/application.yml
+++ b/apps/commerce-batch/src/main/resources/application.yml
@@ -1,0 +1,93 @@
+management:
+  server:
+    port: 8082
+
+server:
+  shutdown: graceful
+  tomcat:
+    threads:
+      max: 200
+      min-spare: 10
+    connection-timeout: 1m
+    max-connections: 8192
+    accept-count: 100
+    keep-alive-timeout: 60s
+  max-http-request-header-size: 8KB
+
+spring:
+  main:
+    web-application-type: servlet
+  application:
+    name: commerce-batch
+  profiles:
+    active: local
+  config:
+    import:
+      - jpa.yml
+      - redis.yml
+      - kafka.yml
+      - logging.yml
+      - monitoring.yml
+
+springdoc:
+  use-fqn: true
+  swagger-ui:
+    path: /swagger-ui.html
+
+logging:
+  level:
+    org.springframework.batch: DEBUG
+    org.springframework.jdbc.core: TRACE
+    org.springframework.batch.item: TRACE
+    # 제거 예정 되지도 않음. insert 쿼리 보이게
+    org.springframework.jdbc.core.JdbcTemplate: DEBUG
+    org.springframework.jdbc.core.StatementCreatorUtils: TRACE
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local, test
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/commerce_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: root1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update   # 개발 편의 → 운영은 none 권장
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+    show-sql: true
+
+  batch:
+    jdbc:
+      initialize-schema: always
+    job:
+      enabled: false # 기본값 true, false 시 배치 앱 실행 시 job 동작 안함
+
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+---
+spring:
+  config:
+    activate:
+      on-profile: qa
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+
+springdoc:
+  api-docs:
+    enabled: false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,7 @@ rootProject.name = "commerces"
 include(
     ":apps:commerce-api",
     ":apps:commerce-streamer",
+    ":apps:commerce-batch",
     ":apps:pg-simulator",
     ":modules:jpa",
     ":modules:redis",


### PR DESCRIPTION
## 📌 Summary

배치 플로우 요약
### 배치 1: 주간 집계 저장 (0시 10분) : 월간 랭킹용 윈도우 
product_metrics에서 최근 7일 데이터 합산 → product_metrics_weekly 저장
### 배치 2: 월간 랭킹 (0시 30분, 배치1 완료 후)
- 슬라이딩 윈도우 형태의 랭킹 점수 계산 
- product_metrics_weekly에서 최근 4개 윈도우(4주) 조회 
- 점수 계산 후 → monthly_ranking_mv 저장
### 배치 3: 주간 랭킹
- 슬라이딩 윈도우 형태의 랭킹 점수 계산 
- product_metrics에서 최근 7개 윈도우(7일) 조회
- 점수 계산 후 → weekly_ranking_mv 저장

## 💬 Review Points
### 1. product_metrics_weekly 생성 배치 구조 : 월간 랭킹을 위한 주간 사용자 행동 count 
<img width="3840" height="1652" alt="image" src="https://github.com/user-attachments/assets/aa0a8af6-c68b-49a9-a914-e5dc6edbb004" />

* 현 구조
    * ItemReader: 그대로 읽음
    * ItemProcessor: bypass (하는 일 없음)
    * ItemWriter: 청크 단위로 넘어온 List<ProductMetrics>를 받아서 → Map<productId, 집계된 metrics> 형태로 변환/집계 →하나의 청크안에서  DB에 insert 를 productId 당 한 번으로 줄일 수 있다는 잇점이 있습니다.
→ Processor는 단건 처리라 집계가 불가능해 어쩔 수 없이 Writer에 책임을 몰아줬습니다.
이 방식(집계 + 변환을 Writer에서 처리)도 괜찮을까요?


### 2. 배치 코드 구조
* Spring Batch 특성상 ItemReader, ItemProcessor, ItemWriter를 사용하면서 repository 메서드 호출시 문자열을 사용하는 것들이 생깁니다. 
* 일반 API 코드와 작성하는 방식이 달라서 코드를 잘 작성한 것인지 궁금합니다. 


### 3. 월간 랭킹 슬라이딩 윈도우
* product_metrics_weekly를 기반으로 4개 윈도우(4주 28일)로 계산 → 슬라이딩 윈도우 방식으로 한 주씩 이동.
* 매일 집계된 주간 데이터를 사용하기 때문에 월간 랭킹도 자동으로 갱신되는 형태.
* 윈도우 계산 시 최근 주차에 가중치를 높게 주었습니다.(Processor에서 반영 가능)

### 4. 배치 실행 방식과 Job 파라미터
* 현재는 스케줄러에서 고정 파라미터를 코드에 주입하는 방식으로 실행했습니다.  
* 하지만 스케쥴러 방식으로 시작하지 않을 때 배치의 멱등성을 보장하기 위해 재실행할 때 특정 기준일을 지정할 수 있도록 Job 파라미터를 받을 수 있게 해두었습니다. 이 부분 잘 된 것인지요? 그리고 보통 배치는 어떻게 실행하는지 궁금합니다.

## ✅ Checklist
<!--
    해당 작업이 완료되었는지 확인하기 위한 체크리스트입니다.
    리뷰어가 확인해야 할 사항을 포함합니다.
    계획중이나 아직 완료되지 않은 작업 또한 `TODO -` 로 작성해주세요.  

    ex.
    - [ ] 테스트 코드 포함
    - [ ] 불필요한 코드 제거
    - [ ] README or 주석 보강 (필요 시)
-->

## 📎 References
<!--
  (Optional: 참고 자료가 없는 작업 - 단순 버그 픽스 등 의 경우엔 해당 란을 제거해주세요 !)
  리뷰어가 참고할 수 있는 추가적인 정보나 문서, 링크 등을 작성해주세요.
  예시:
  - 관련 문서 링크
  - 관련 정책 링크
-->